### PR TITLE
Add initial static publisher prototype 

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -144,3 +144,11 @@ $govuk-assets-path: "/govuk/assets/";
 .form-action-group {
   justify-content: flex-end;
 }
+
+.comment {
+  border-bottom: 1px solid $govuk-border-colour;
+
+  &:last-of-type {
+    border-bottom: 0;
+  }
+}

--- a/app/views/form-builder-prototypes.html
+++ b/app/views/form-builder-prototypes.html
@@ -52,6 +52,22 @@
             <li>a persitant preview pane provides reassurance about the final form</li>
           </ul>
 
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+          <h2 class="govuk-heading-m">
+            Form publisher
+          </h2>
+
+          <p>
+            <b>
+              <a href="/publisher/start">View the prototype</a>
+            </b>
+          </p>
+
+          <p>
+            A basic form publisher with some approval features.
+          </p>
+
         </div>
       </div>
 

--- a/app/views/publisher/confirm-email.html
+++ b/app/views/publisher/confirm-email.html
@@ -1,0 +1,48 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Confirm your email
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-label--l">Confirm your email</h1>
+            <p>A 6-digit verification code has been sent to the email address you entered on the previous page.</p>
+            <form action="email-confirmed" method="post" novalidate>
+                {{ govukInput({
+                    label: {
+                        text: "Enter your 6-digit verification code",
+                        classes: "govuk-label--m"
+                    },
+                    hint: {
+                        text: 'If you do not have access to the inbox, contact the team within your department who are responsible for it.'
+                    },
+                    id: "inbox-verification-code",
+                    name: "inbox-verification-code",
+                    classes: "govuk-!-margin-bottom-1",
+                    formGroup: {
+                        classes: "govuk-!-margin-bottom-1"
+                    }
+                }) }}
+
+                {{ govukButton({
+                    text: "Next page"
+                }) }}
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row"></div>
+{% endblock %}

--- a/app/views/publisher/declaration.html
+++ b/app/views/publisher/declaration.html
@@ -1,0 +1,42 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Declaration
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-label--l">Declaration</h1>
+            <p>I declare that:
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>I am publishing this form in my role as a civil servant, not for any private purpose.</li>
+                    <li>I have followed any approval rules currently in force within my team and my department.</li>
+                </ul>
+            </p>
+            <p>I understand that:
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>publishing this form will make it live.</li>
+                    <li>live forms are visible to search engines, and as a result they may be accessed by members of the public, regardless of whether they are linked to from GOV.UK or any other government website.</li>
+                </ul>
+            </p>
+
+            {{ govukButton({
+                text: "Accept declaration and publish form",
+                href: "published"
+            }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/app/views/publisher/email-confirmed.html
+++ b/app/views/publisher/email-confirmed.html
@@ -1,0 +1,31 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Email address verified
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-label--l">Email address email-confirmed</h1>
+            <p>Your email address has been confirmed.</p>
+
+            {{ govukButton({
+                text: "Next page",
+                href: "declaration"
+            }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/app/views/publisher/enter-email.html
+++ b/app/views/publisher/enter-email.html
@@ -1,0 +1,47 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Enter email address
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <form action="#" method="post" novalidate>
+                {{ govukInput({
+                    label: {
+                        text: "What email address should form responses be sent to?",
+                        classes: "govuk-label--l",
+                        isPageHeading: true
+                    },
+                    hint: {
+                        text: 'If you are publishing to the live environment, this must be a shared inbox.'
+                    },
+                    id: "response-inbox",
+                    name: "response-inbox",
+                    classes: "govuk-!-margin-bottom-1",
+                    formGroup: {
+                        classes: "govuk-!-margin-bottom-1"
+                    }
+                }) }}
+
+                {{ govukButton({
+                    text: "Next page"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/app/views/publisher/form-summary.html
+++ b/app/views/publisher/form-summary.html
@@ -1,0 +1,62 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Form Summary - Apply for a Roller Disco Licence
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Apply for a Roller Disco Licence (Draft)</h1>
+
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h3 class="govuk-heading-m">Draft URL</h3>
+            <p>
+                <a href="#">https://apply-for-a-roller-disco-licence.draft.forms.service.gov.uk</a>
+            </p>
+
+            <h3 class="govuk-heading-m">Review URL</h3>
+            <p>
+                <a href="review">https://apply-for-a-roller-disco-licence.draft.forms.service.gov.uk/review</a>
+            </p>
+
+            <h3 class="govuk-heading-m">Actions</h3>
+
+            <div class="govuk-button-group">
+                {{ govukButton({
+                    text: "Edit form",
+                    href: '/form-designer/form-index'
+                }) }}
+                {{ govukButton({
+                    text: "Send for review",
+                    href: "review"
+                }) }}
+                {{ govukButton({
+                    text: "Publish form",
+                    href: "confirm-email"
+                }) }}
+            </div>
+        </div>
+        <div class="govuk-grid-column-one-third">
+            <p>Status: <span class="govuk-!-font-weight-bold">Draft</span></p>
+            <p>Last modified by <span class="govuk-!-font-weight-bold">Laura Mipsum</span> on 20th November 2021 at 15:45</p>
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/views/publisher/published.html
+++ b/app/views/publisher/published.html
@@ -1,0 +1,60 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Published: Apply for a Roller Disco Licence
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Apply for a Roller Disco Licence (Live)</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p>
+                Your form has now been published.
+            </p>
+            <p>You should now contact your GOV.UK publisher to arrange for this form to be linked to from GOV.UK.</p>
+            <h3 class="govuk-heading-m">Live URL</h3>
+            <p>
+                <a href="#">https://apply-for-a-roller-disco-licence.forms.service.gov.uk</a>
+            </p>
+
+            <h3 class="govuk-heading-m">Actions</h3>
+
+            <div class="govuk-button-group">
+                {{ govukButton({
+                    text: "Edit form",
+                    href: '/form-designer/form-index'
+                }) }}
+                {{ govukButton({
+                    text: "Unpublish form",
+                    href: "form-summary"
+                }) }}
+                {{ govukButton({
+                    text: "View my forms",
+                    href: "start"
+                }) }}
+            </div>
+        </div>
+        <div class="govuk-grid-column-one-third">
+            <p>Status: <span class="govuk-!-font-weight-bold">Published</span></p>
+            <p>Published by <span class="govuk-!-font-weight-bold">Laura Mipsum</span> on 20th November 2021 at 15:45</p>
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/views/publisher/review-question.html
+++ b/app/views/publisher/review-question.html
@@ -1,0 +1,82 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Reviewing question: Name
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            <form action="#" method="post" novalidate>
+                {{ govukInput({
+                    label: {
+                        text: "What is your name?",
+                        classes: "govuk-label--l",
+                        isPageHeading: true
+                    },
+                    hint: {
+                        text: 'Please enter your full name, including any middle names.'
+                    },
+                    id: "review-comment",
+                    name: "review-comment",
+                    classes: "govuk-!-margin-bottom-1",
+                    formGroup: {
+                        classes: "govuk-!-margin-bottom-1"
+                    }
+                }) }}
+
+                {{ govukButton({
+                    text: "Next page"
+                }) }}
+            </form>
+        </div>
+        <div class="govuk-grid-column-one-third">
+            <h2 class="govuk-heading-l">Reviewer comments</h2>
+            <div class="comment govuk-!-margin-bottom-3">
+                <div class="media-body">
+                    <p class="govuk-body media-heading">
+                        <span class="govuk-visually-hidden">Comment by</span>
+                        <span class="author govuk-!-font-weight-bold">elissavet.gianouli@djrs.gov.uk</span>
+                        <span class="govuk-visually-hidden">posted on</span>
+                        <time datetime="2021-08-16T00:34:34+01:00">on 16 August 2021</time>
+                    </p>
+                    <div class="comment-body">
+                        <p>Do we really need to collect middle names here?</p>
+                    </div>
+                </div>
+            </div>
+            <form action="#" method="post" novalidate>
+                {{ govukTextarea({
+                    label: {
+                        text: "Add a comment",
+                        classes: "govuk-label--s"
+                    },
+                    id: "review-comment",
+                    name: "review-comment",
+                    classes: "govuk-!-margin-bottom-1",
+                    formGroup: {
+                        classes: "govuk-!-margin-bottom-1"
+                    }
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit feedback"
+                }) }}
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row"></div>
+{% endblock %}

--- a/app/views/publisher/review.html
+++ b/app/views/publisher/review.html
@@ -1,0 +1,195 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Reviewing form: Apply for a Roller Disco Licence
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        "text": "Back",
+        "href": "javascript: window.history.go(-1)"
+        }) 
+    }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Reviewing form: Apply for a Roller Disco Licence</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-l">Form pages</h2>
+            {{ govukTable({
+                head: [
+                    {
+                        text: "Question"
+                    },
+                    {
+                        text: "Type"
+                    },
+                    {
+                        text: "Required"
+                    },
+                    {
+                        text: "Changed since last publish"
+                    }
+                ],
+                rows: [
+                    [
+                        {
+                            html: "<a href='review-question.html'>Name</a>"
+                        },
+                        {
+                            text: "Text"
+                        },
+                        {
+                            text: "Yes"
+                        },
+                        {
+                            text: "Yes"
+                        }
+                    ],
+                    [
+                        {
+                            html: "<a href='review-question.html'>Address</a>"
+                        },
+                        {
+                            text: "Long text"
+                        },
+                        {
+                            text: "Yes"
+                        },
+                        {
+                            text: "No"
+                        }
+                    ],
+                    [
+                        {
+                            html: "<a href='review-question.html'>Date of birth</a>"
+                        },
+                        {
+                            text: "Date"
+                        },
+                        {
+                            text: "No"
+                        },
+                        {
+                            text: "No"
+                        }
+                    ],
+                    [
+                        {
+                            html: "<a href='review-question.html'>Trading name</a>"
+                        },
+                        {
+                            text: "Text"
+                        },
+                        {
+                            text: "Yes"
+                        },
+                        {
+                            text: "No"
+                        }
+                    ],
+                    [
+                        {
+                            html: "<a href='review-question.html'>Capacity</a>"
+                        },
+                        {
+                            text: "Number"
+                        },
+                        {
+                            text: "Yes"
+                        },
+                        {
+                            text: "No"
+                        }
+                    ]
+                ]
+            }) }}
+            <h2 class="govuk-heading-l">Comments</h2>
+            <div class="comment govuk-!-margin-bottom-3">
+                <div class="media-body">
+                    <p class="govuk-body media-heading">
+                        <span class="govuk-visually-hidden">Comment by</span>
+                        <span class="author govuk-!-font-weight-bold">elissavet.gianouli@djrs.gov.uk</span>
+                        <span class="govuk-visually-hidden">posted on</span>
+                        <time datetime="2021-08-16T00:34:34+01:00">on 16 August 2021</time>
+                    </p>
+                    <div class="comment-body">
+                        <p>The new address field looks good. I'm happy with the changes!</p>
+                    </div>
+                </div>
+            </div>
+            <div class="comment">
+                <div class="media-body">
+                    <p class="govuk-body media-heading">
+                        <span class="govuk-visually-hidden">Comment by</span>
+                        <span class="author govuk-!-font-weight-bold">nina.licheli@djrs.gov.uk</span>
+                        <span class="govuk-visually-hidden">posted on</span>
+                        <time datetime="2021-08-16T00:34:34+01:00">on 16 August 2021</time>
+                    </p>
+                    <div class="comment-body">
+                        <p>I agree with Elissavet - this looks good.</p>
+                    </div>
+                </div>
+            </div>
+            <form action="#" method="post" novalidate>
+                {{ govukTextarea({
+                    label: {
+                        text: "Add a comment",
+                        classes: "govuk-label--s"
+                    },
+                    id: "review-comment",
+                    name: "review-comment",
+                    classes: "govuk-!-margin-bottom-1",
+                    formGroup: {
+                        classes: "govuk-!-margin-bottom-1"
+                    }
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit feedback"
+                }) }}
+            </form>
+        </div>
+        <div class="govuk-grid-column-one-third">
+            <h2 class="govuk-heading-m">Current reviewers</h3>
+            <p>You have requested reviews from:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>elissavet.gianouli@djrs.gov.uk</li>
+                <li>nina.licheli@djrs.gov.uk</li>
+            </ul>
+            <h2 class="govuk-heading-m">Add reviewer</h2>
+            <form action="#" method="post" novalidate>
+
+                {{ govukInput({
+                    label: {
+                        text: "Email address of reviewer",
+                        classes: "govuk-label--s",
+                        isPageHeading: false
+                    },
+                    hint: {
+                        text: "Your reviewer will receive a link to this page"
+                    },
+                    id: "reviewer-email",
+                    name: "reviewer-email",
+                    type: "email",
+                    autocomplete: "email",
+                    spellcheck: false
+                }) }}
+
+                {{ govukButton({
+                    text: "Send for review"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/app/views/publisher/start.html
+++ b/app/views/publisher/start.html
@@ -20,32 +20,32 @@
             {{ govukTable({
                 head: [
                     {
-                    text: "Form name"
+                        text: "Form name"
                     },
                     {
-                    text: "Author"
+                        text: "Author"
                     },
                     {
-                    text: "Status"
+                        text: "Status"
                     },
                     {
-                    text: "Last modified"
+                        text: "Last modified"
                     }
                 ],
                 rows: [
                     [
-                    {
-                        html: "<a href='form-summary.html'>Apply for a roller disco licence</a>"
-                    },
-                    {
-                        text: "Laura Mipsum"
-                    },
-                    {
-                        text: "Draft"
-                    },
-                    {
-                        text: "20th November 2021 at 15:45"
-                    }
+                        {
+                            html: "<a href='form-summary.html'>Apply for a roller disco licence</a>"
+                        },
+                        {
+                            text: "Laura Mipsum"
+                        },
+                        {
+                            text: "Draft"
+                        },
+                        {
+                            text: "20th November 2021 at 15:45"
+                        }
                     ]
                 ]
             }) }}
@@ -55,45 +55,46 @@
             {{ govukTable({
                 head: [
                     {
-                    text: "Form name"
+                        text: "Form name"
                     },
                     {
-                    text: "Author"
+                        text: "Author"
                     },
                     {
-                    text: "Status"
+                        text: "Status"
                     },
                     {
-                    text: "Last modified"
+                        text: "Last modified"
                     }
                 ],
-                rows: [ [
-                    {
-                        html: "<a href='form-summary.html'>Claim quad skates discount</a>"
-                    },
-                    {
-                        text: "Paul Farmer"
-                    },
-                    {
-                        text: "Published"
-                    },
-                    {
-                        text: "6th February 2021 at 09:31"
-                    }
-                    ],
+                rows: [ 
                     [
-                    {
-                        html: "<a href='form-summary.html'>Register as a skating trainer</a>"
-                    },
-                    {
-                        text: "Rita Patel"
-                    },
-                    {
-                        text: "Staging"
-                    },
-                    {
-                        text: "19th October 2021 at 12:19"
-                    }
+                        {
+                            html: "<a href='form-summary.html'>Claim quad skates discount</a>"
+                        },
+                        {
+                            text: "Paul Farmer"
+                        },
+                        {
+                            text: "Published"
+                        },
+                        {
+                            text: "6th February 2021 at 09:31"
+                        }
+                        ],
+                        [
+                        {
+                            html: "<a href='form-summary.html'>Register as a skating trainer</a>"
+                        },
+                        {
+                            text: "Rita Patel"
+                        },
+                        {
+                            text: "Staging"
+                        },
+                        {
+                            text: "19th October 2021 at 12:19"
+                        }
                     ]
                 ]
             }) }}
@@ -106,25 +107,25 @@
             {{ govukTabs({
                 items: [
                     {
-                    label: "Published (1)",
-                    id: "past-day",
-                    panel: {
-                        html: publishedHtml
-                    }
-                    },
-                    {
-                    label: "Draft (2)",
-                    id: "past-week",
-                    panel: {
-                        html: draftHtml
-                    }
-                    },
-                    {
-                    label: "Trash (0)",
-                    id: "past-month",
-                    panel: {
-                        html: trashHtml
-                    }
+                        label: "Published (1)",
+                        id: "past-day",
+                        panel: {
+                            html: publishedHtml
+                        }
+                        },
+                        {
+                        label: "Draft (2)",
+                        id: "past-week",
+                        panel: {
+                            html: draftHtml
+                        }
+                        },
+                        {
+                        label: "Trash (0)",
+                        id: "past-month",
+                        panel: {
+                            html: trashHtml
+                        }
                     }
                 ]
             }) }}

--- a/app/views/publisher/start.html
+++ b/app/views/publisher/start.html
@@ -1,0 +1,134 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+    Your forms
+{% endblock %}
+
+{% block header %}
+    {{ govukHeader() }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-xl">Your forms</h1>
+            {{ govukButton({
+                text: "Create a new form"
+            }) }}
+            {% set publishedHtml %}
+            {{ govukTable({
+                head: [
+                    {
+                    text: "Form name"
+                    },
+                    {
+                    text: "Author"
+                    },
+                    {
+                    text: "Status"
+                    },
+                    {
+                    text: "Last modified"
+                    }
+                ],
+                rows: [
+                    [
+                    {
+                        html: "<a href='form-summary.html'>Apply for a roller disco licence</a>"
+                    },
+                    {
+                        text: "Laura Mipsum"
+                    },
+                    {
+                        text: "Draft"
+                    },
+                    {
+                        text: "20th November 2021 at 15:45"
+                    }
+                    ]
+                ]
+            }) }}
+            {% endset -%}
+
+            {% set draftHtml %}
+            {{ govukTable({
+                head: [
+                    {
+                    text: "Form name"
+                    },
+                    {
+                    text: "Author"
+                    },
+                    {
+                    text: "Status"
+                    },
+                    {
+                    text: "Last modified"
+                    }
+                ],
+                rows: [ [
+                    {
+                        html: "<a href='form-summary.html'>Claim quad skates discount</a>"
+                    },
+                    {
+                        text: "Paul Farmer"
+                    },
+                    {
+                        text: "Published"
+                    },
+                    {
+                        text: "6th February 2021 at 09:31"
+                    }
+                    ],
+                    [
+                    {
+                        html: "<a href='form-summary.html'>Register as a skating trainer</a>"
+                    },
+                    {
+                        text: "Rita Patel"
+                    },
+                    {
+                        text: "Staging"
+                    },
+                    {
+                        text: "19th October 2021 at 12:19"
+                    }
+                    ]
+                ]
+            }) }}
+            {% endset -%}
+
+            {% set trashHtml %}
+            <p>You have no forms in Trash.</p>
+            {% endset -%}
+
+            {{ govukTabs({
+                items: [
+                    {
+                    label: "Published (1)",
+                    id: "past-day",
+                    panel: {
+                        html: publishedHtml
+                    }
+                    },
+                    {
+                    label: "Draft (2)",
+                    id: "past-week",
+                    panel: {
+                        html: draftHtml
+                    }
+                    },
+                    {
+                    label: "Trash (0)",
+                    id: "past-month",
+                    panel: {
+                        html: trashHtml
+                    }
+                    }
+                ]
+            }) }}
+        </div>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
This adds an inital prototype for the approval and publishing workflow.
At present, it's not particularly interactive - you'll be able to navigate through the pages, and it will seem like you're going through a 'happy path' journey, but none of the text inputs will actually do anything.