### PR TITLE
fix: in-page-preview stopped showing styling

### DIFF
--- a/app/views/form-designer/edit-check-answers-page.html
+++ b/app/views/form-designer/edit-check-answers-page.html
@@ -77,7 +77,7 @@
             <a href="../check-answers-page-preview-new-tab" target="_blank">Open in a new tab</a>
           </p>
         </div>
-        <iframe sandbox title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../check-answers-page-preview" frameborder="1" loading="lazy" id="iFrameResizer0" ></iframe>
+        <iframe sandbox="allow-same-origin allow-scripts" title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../check-answers-page-preview" frameborder="1" loading="lazy" id="iFrameResizer0" ></iframe>
         {{ govukButton({
           text: "Update preview",
           classes: "update-button",

--- a/app/views/form-designer/edit-confirmation-page.html
+++ b/app/views/form-designer/edit-confirmation-page.html
@@ -77,7 +77,7 @@
             <a href="../confirmation-page-preview-new-tab" target="_blank">Open in a new tab</a>
           </p>
         </div>
-        <iframe sandbox title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../confirmation-page-preview" frameborder="1" loading="lazy" id="iFrameResizer0" scrolling="no" ></iframe>
+        <iframe sandbox="allow-same-origin allow-scripts" title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../confirmation-page-preview" frameborder="1" loading="lazy" id="iFrameResizer0" scrolling="no" ></iframe>
         {{ govukButton({
           text: "Update preview",
           classes: "update-button",

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -337,7 +337,7 @@
               <!-- <a href="#" target="_blank" onclick="document.getElementById('form').submit();">Refresh</a> &nbsp;|&nbsp; -->
             </p>
           </div>
-          <iframe sandbox title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../page-preview/{{pageId}}" frameborder="1" loading="lazy" id="iFrameResizer0"></iframe>
+          <iframe sandbox="allow-same-origin allow-scripts" title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../page-preview/{{pageId}}" frameborder="1" loading="lazy" id="iFrameResizer0"></iframe>
 
         </div>
       </div>


### PR DESCRIPTION
The preview shows unstyled content.

This is because the sandbox attribute was added to the iframe containing
the preview. sandbox prevents the iframe loading content from the same
origin and runninng scripts.

It's been changed to:

sandbox="allow-same-origin allow-scripts"

This doesn't provide much security - in our case we are not worried
about that, so it shouldn't matter unless we stop trusting the content
of the iframe at some point.