### PR TITLE
Remove sticky functionality from in page preview

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -18,11 +18,15 @@ $govuk-assets-path: "/govuk/assets/";
 // Project partials
 @import "patterns/moj-messages";
 
+/*  Remove sticky pane
+    Allow content to be left aligned
 .preview-pane-wrapper {
   position: sticky;
   top: 110px;
   text-align: center;
 }
+*/
+
 .preview-pane {
   overflow: hidden;
   height: 570px;


### PR DESCRIPTION
I have commented out the in page preview CSS for now. This includes the text-align of the text within the wrapper so we can have content and links left aligned. 

This update won't change the inline style height added, that'll be part of [issue 40](https://github.com/alphagov/forms-prototypes/issues/40).

