### PR TITLE
38 reorganise page list

### DIFF
--- a/app/views/form-designer/form-create-a-form.html
+++ b/app/views/form-designer/form-create-a-form.html
@@ -22,7 +22,8 @@
           text: "Use a name that describes what the form will help people to do. For example ‘Apply for a licence’."
         },
         id: "event-name",
-        name: "formTitle"
+        name: "formTitle",
+        value: data['formTitle'] 
         }) }}
 
 

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -43,7 +43,7 @@
 
           {% for page in data.pages -%}
 
-            {% set questionTitle = page["short-title"]  or page["long-title"] or "Page " + page["pageIndex"] %}
+            {% set questionTitle =  page["long-title"] or page["short-title"] or "Page " + page["pageIndex"] %}
 
             {% if questionTitle %}
 

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -53,7 +53,7 @@
                   {{questionTitle}}
                 </dt>
                 <dd class="govuk-summary-list__actions">
-                  <div class="govuk-button-group form-action-group">
+                  <div class="govuk-button-group form-action-group govuk-!-margin-bottom-0">
                     {% if page.pageIndex > 0 %}
                       {{ govukButton({
                           text: "Up",
@@ -82,11 +82,12 @@
           {%- endfor %}
           </dl>
 
-          <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Generated questions</h2>
+          <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Standard pages</h2>
           <dl class="govuk-summary-list">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                Check your answers
+            <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+            <p>Check your answers</p>
+                <p class="govuk-hint">This page lists all the questions and answers so people can check them before they submit the form. You can add a declaration for people to confirm their answers.</p>
               </dt>
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link govuk-link--no-visited-state" href="edit-page/check-answers">
@@ -95,8 +96,9 @@
           </div>
 
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                Confirmation
+            <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+            <p>Confirmation</p>
+            <p class="govuk-hint">This page will be shown to confirm the form has been submitted. You can add information to tell people what will happen next.</p>
               </dt>
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link govuk-link--no-visited-state" href="edit-page/confirmation">
@@ -106,6 +108,7 @@
         </dl>
 
       <div class="govuk-!-margin-top-9">
+        <h2 class="govuk-heading-m">Next steps</h2>
         <p><a href="/form-designer/start-page-preview-new-tab" target="_blank">Test the form in a new tab</a></p>
         {{ govukButton({
             text: "Publish form",

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -10,39 +10,36 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-l">Form</span>
-        <h1 class="govuk-heading-l">{{ data['formTitle'] }}</h1>
+        <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
+        <h1 class="govuk-heading-l">Form overview</h1>
 
         {% set nextPageId = data['highestPageId'] | int + 1 %}
         {% set totalPageNum = data['highestPageId'] | int + 2 %}
 
-        <p class="govuk-body-s">{{totalPageNum}} page draft form{% if data['highestPageId'] > 0 %} —
-        <a href="form-publish" class="form-publish govuk-link--no-visited-state">Publish</a>
-          {% endif %}.
-      </p>
-
       {{ govukButton({
           text: "Add a question",
-          href: "choose-page-type/" + nextPageId
+          href: "choose-page-type/" + nextPageId,
+          classes: "govuk-!-margin-bottom-3 govuk-!-margin-top-3"
         }) }}
 
-        <p><a href="/form-designer/start-page-preview-new-tab" target="_blank">Preview form (opens in new tab)</a></p>
 
+
+        {% if data.pages.length %}
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Form name</h2>
 
         <dl class="govuk-summary-list">
-          
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+          {{ data['formTitle'] }}
+            </dt>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="form-create-a-form.html"> Edit</a>
+          </dd>
+        </div>
+      </dl>
 
-          <!-- Add this if users are confused about where their pages go
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                <a class=" govuk-link--no-visited-state" href="choose-page-type/{{nextPageId}}">Create a new page</a>
-              </dt>
-              <dd class="govuk-summary-list__value govuk-!-width-one-quarter">
-              </dd>
-                <dd class="govuk-summary-list__actions">
-                </dd>
-            </div>
-            -->
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Your questions</h2>
+        <dl class="govuk-summary-list">
 
           {% for page in data.pages -%}
 
@@ -83,7 +80,10 @@
             {% endif %}
 
           {%- endfor %}
+          </dl>
 
+          <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Generated questions</h2>
+          <dl class="govuk-summary-list">
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
                 Check your answers
@@ -105,6 +105,15 @@
           </div>
         </dl>
 
+      <div class="govuk-!-margin-top-9">
+        <p><a href="/form-designer/start-page-preview-new-tab" target="_blank">Test the form in a new tab</a></p>
+        {{ govukButton({
+            text: "Publish form",
+            classes: "govuk-button--secondary",
+            href: "form-publish"
+          }) }}
+      </div>
+      {% endif %}
       </div>
 
     </div>


### PR DESCRIPTION
Change the layout and text of the page list - both empty and when there are questions on it.

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/11035856/167605236-add769b8-9965-4a5d-8442-96e91fd5411b.png">

![image](https://user-images.githubusercontent.com/11035856/167605635-0f6901f3-793b-482b-a497-31d3376cfa40.png)
