### PR TITLE
37 page list make the form name field mandatory and add error messages

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -22,7 +22,6 @@ module.exports = {
   // Insert values here
 
   highestPageId: 0,
-  formTitle: 'Untitled form',
   action: '',
   publish: 'GOV.UK',
   authentication: 'email',

--- a/app/routes.js
+++ b/app/routes.js
@@ -156,4 +156,30 @@ router.get('/form-designer/page-preview-new-tab/:pageId', function (req, res) {
   })
 })
 
+// Renders the page which asks for form name, handling validation errors
+router.post('/form-designer/form-create-a-form', function (req, res) {
+  const errors = {};
+  const { formTitle } = req.session.data
+
+  // If the formTitle is blank, create an error to be displayed to the user
+  if (!formTitle || !formTitle.length) {
+    errors['formTitle'] = {
+      text: 'Enter a form name',
+      href: "#form-title"
+    }
+  }
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  if(containsErrors) {
+    res.render('form-designer/form-create-a-form', { errors, errorList, containsErrors })
+  } else {
+    res.redirect('form-index')
+  }
+})
+
+
 module.exports = router

--- a/app/views/form-designer/form-create-a-form.html
+++ b/app/views/form-designer/form-create-a-form.html
@@ -24,7 +24,7 @@
         isPageHeading: true
         },
         hint: {
-          text: "Use a name that describes what the form will help people to do. For example ‘Apply for a licence’."
+          text: "The form name will be shown at the top of each page of the form. Use a name that describes what the form will help people to do. For example ‘Apply for a juggling licence’."
         },
         id: "form-title",
         name: "formTitle",

--- a/app/views/form-designer/form-create-a-form.html
+++ b/app/views/form-designer/form-create-a-form.html
@@ -1,16 +1,21 @@
 {% extends "layout-govuk-forms.html" %}
 
+
 {% block pageTitle %}
-  Create a form
+  {{ "Error:" if containsErrors }} Create a form
 {% endblock %}
 
 {% block content %}
+  {% if containsErrors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errorList
+    }) }}
+  {% endif %}
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-      <form class="form" action="form-index" method="post">
-
-        {% from "govuk/components/input/macro.njk" import govukInput %}
+      <form class="form" method="post">
 
         {{ govukInput({
         label: {
@@ -21,9 +26,10 @@
         hint: {
           text: "Use a name that describes what the form will help people to do. For example ‘Apply for a licence’."
         },
-        id: "event-name",
+        id: "form-title",
         name: "formTitle",
-        value: data['formTitle'] 
+        value: data['formTitle'],
+        errorMessage: { text: errors['formTitle'].text } if errors['formTitle'].text
         }) }}
 
 


### PR DESCRIPTION
Added error handling for form name screen -  if you don't put anything in the entry box, you get the errors.

There was no text for this so I made it up.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/11035856/167608900-eaec4431-d82a-4fb6-a98b-4d003bdb8704.png">
