### PR TITLE
Remove interactivity of in page previews across journey

### DIFF
--- a/app/views/form-designer/check-answers-page-preview.html
+++ b/app/views/form-designer/check-answers-page-preview.html
@@ -1,32 +1,25 @@
 {% extends "layout-body-only.html" %}
 
 {% block pageTitle %}
-  Start page
+  {{data['checkAnswersTitle']}} - GOV.UK Forms
 {% endblock %}
 
-{% block header %}
+{% block header %}{% endblock %}
 
-{% endblock %}
-
-{% block beforeContent %}
-  <a class="govuk-back-link" href="./edit-page/{{data['highestPageId']}}" target="_parent">Back</a>
-{% endblock %}
+{% block beforeContent %}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    <h1 class="govuk-panel__title">{{data['checkAnswersTitle']}}</h1>
 
-  <h1 class="govuk-panel__title">{{data['checkAnswersTitle']}}</h1>
+    <dl class="govuk-summary-list">
+      {% for page in data.pages -%}
 
+        {% set questionTitle = page["short-title"]  or page["long-title"] or "Page " + page["pageIndex"] %}
 
-      <dl class="govuk-summary-list">
-        {% for page in data.pages -%}
-
-            {% set questionTitle = page["short-title"]  or page["long-title"] or "Page " + page["pageIndex"] %}
-
-          {% if questionTitle %}
-
+        {% if questionTitle %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
               <!--Q{{page["pageIndex"] | int + 1}}.--> {{questionTitle}}
@@ -34,36 +27,31 @@
             <dd class="govuk-summary-list__value">
             </dd>
               <dd class="govuk-summary-list__actions">
-                  <a class="govuk-link govuk-link--no-visited-state" href="edit-page/{{loop.index}}" target="_parent">
-                    Change
-                  </a>
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-page/{{loop.index}}" target="_parent">
+                  Change
+                </a>
               </dd>
           </div>
-          {% endif %}
+        {% endif %}
 
-        {%- endfor %}
-
-      </dl>
-
+      {%- endfor %}
+    </dl>
 
     {% if data['checkAnswersDeclaration'] %}
-    <h2 class="govuk-heading-m">Declaration</h2>
+      <h2 class="govuk-heading-m">Declaration</h2>
 
-    <div class="app-prose-scope">
-    {% markdown %}
-      {{ data['checkAnswersDeclaration'] }}
-    {% endmarkdown %}
-    </div>
-
+      <div class="app-prose-scope">
+      {% markdown %}
+        {{ data['checkAnswersDeclaration'] }}
+      {% endmarkdown %}
+      </div>
     {% endif %}
 
     {{ govukButton({
       text: "Agree and submit",
-      href: "./edit-page/confirmation",
-      attributes: {
-        target: "_parent"
-      }
+      disabled: true
     }) }}
+
   </div>
 </div>
 {% endblock %}

--- a/app/views/form-designer/confirmation-page-preview.html
+++ b/app/views/form-designer/confirmation-page-preview.html
@@ -1,12 +1,12 @@
 {% extends "layout-body-only.html" %}
 
 {% block pageTitle %}
-  Start page
+  {{data['confirmationTitle']}} - GOV.UK Forms
 {% endblock %}
 
-{% block header %}
+{% block header %}{% endblock %}
 
-{% endblock %}
+{% block beforeContent %}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
@@ -20,15 +20,15 @@
     </div>
 
     {% if data['confirmationNext'] %}
-    <h2 class="govuk-heading-m">What happens next</h2>
+      <h2 class="govuk-heading-m">What happens next</h2>
 
-    <div class="app-prose-scope">
-    {% markdown %}
-      {{ data['confirmationNext'] }}
-    {% endmarkdown %}
-    </div>
-
+      <div class="app-prose-scope">
+      {% markdown %}
+        {{ data['confirmationNext'] }}
+      {% endmarkdown %}
+      </div>
     {% endif %}
+
   </div>
 </div>
 {% endblock %}

--- a/app/views/form-designer/page-preview-placeholder.html
+++ b/app/views/form-designer/page-preview-placeholder.html
@@ -1,5 +1,8 @@
 {% extends "layout-body-only.html" %}
 
+{% block beforeContent %}
+{% endblock %}
+
 {% block pageTitle %}
   Edit question
 {% endblock %}
@@ -17,19 +20,18 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">Page title</h1>
+      <h1 class="govuk-heading-l">Page title</h1>
 
-    <p style="background: #f3f2f1">&nbsp;</p>
-    <p style="background: #f3f2f1">&nbsp;</p>
-    <p style="background: #f3f2f1">&nbsp;</p>
-    <p style="background: #f3f2f1">&nbsp;</p>
-    <p style="background: #f3f2f1">&nbsp;</p>
+      <p style="background: #f3f2f1">&nbsp;</p>
+      <p style="background: #f3f2f1">&nbsp;</p>
+      <p style="background: #f3f2f1">&nbsp;</p>
+      <p style="background: #f3f2f1">&nbsp;</p>
+      <p style="background: #f3f2f1">&nbsp;</p>
 
-
-        {{ govukButton({
-          text: "Continue",
-          disabled: true
-        }) }}
+      {{ govukButton({
+        text: "Continue",
+        disabled: true
+      }) }}
 
     </div>
   </div>

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -1,14 +1,12 @@
 {% extends "layout-body-only.html" %}
 
 {% block pageTitle %}
-  Edit question
+  {{ pageData['long-title'] }} - GOV.UK Forms
 {% endblock %}
 
 {% block header %}{% endblock %}
 
 {% block beforeContent %}
-  {% set prevPageId = pageId - 1 %}
-  <a class="govuk-back-link" href="../edit-page/{{prevPageId}}" target="_parent">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -229,14 +227,14 @@
             {{ pageData['hint-text']}}
           </div>
           <div class="govuk-radios">
-                {% for item in itemsArray %}
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="question-1-{{ item }}" name="question-1-" type="radio" value="{{ item }}">
-                  <label class="govuk-label govuk-radios__label" for="question-1-{{ item }}">
-                    {{ item }}
-                  </label>
-                </div>
-                {% endfor %}
+            {% for item in itemsArray %}
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="question-1-{{ item }}" name="question-1-" type="radio" value="{{ item }}">
+              <label class="govuk-label govuk-radios__label" for="question-1-{{ item }}">
+                {{ item }}
+              </label>
+            </div>
+            {% endfor %}
           </div>
         </fieldset>
         </div>
@@ -293,30 +291,10 @@
         {% endif %}
 
         {# Submit button #}
-
-        {% set nextPageId = pageId | int + 1 %}
-
-        {% if pageId == data['highestPageId'] %}
-
-          {{ govukButton({
-          text: "Check your answers",
-          href: "../edit-page/check-answers",
-          attributes: {
-            target: "_parent"
-          }
-        }) }}
-
-        {% else %}
-
-          {{ govukButton({
+        {{ govukButton({
           text: "Continue",
-          href: "../edit-page/" + nextPageId,
-          attributes: {
-            target: "_parent"
-          }
+          disabled: true
         }) }}
-
-        {% endif %}
 
       </div>
     </div>


### PR DESCRIPTION
Reduced/removed interactive elements from the in page preview iframes. 

This should cover:

- page-preview.html
- confirmation-page-preview.html
- check-answers-page-preview.html

### Additional changes made:

- updated/fixed tab titles to match the heading of the page - not sure how big an impact this has, but could affect screen reader users
- 