### PR TITLE
Add return journey prototype

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -17,6 +17,7 @@ $govuk-assets-path: "/govuk/assets/";
 
 // Project partials
 @import "patterns/moj-messages";
+@import "patterns/govuk-publishing-document-list";
 
 /*  Remove sticky pane
     Allow content to be left aligned

--- a/app/assets/sass/patterns/_govuk-publishing-document-list.css
+++ b/app/assets/sass/patterns/_govuk-publishing-document-list.css
@@ -1,0 +1,116 @@
+.gem-c-document-list {
+  color: #0b0c0c;
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0;
+  padding: 0;
+}
+@media print {
+  .gem-c-document-list {
+    color: #000000;
+  }
+}
+@media print {
+  .gem-c-document-list {
+    font-family: sans-serif;
+  }
+}
+@media (min-width: 40.0625em) {
+  .gem-c-document-list {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
+  }
+}
+@media print {
+  .gem-c-document-list {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.gem-c-document-list__item {
+  margin-bottom: 25px;
+  padding-top: 10px;
+  border-top: 1px solid #b1b4b6;
+  list-style: none;
+}
+
+.gem-c-document-list__item-title {
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  display: inline-block;
+}
+@media print {
+  .gem-c-document-list__item-title {
+    font-family: sans-serif;
+  }
+}
+@media (min-width: 40.0625em) {
+  .gem-c-document-list__item-title {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
+  }
+}
+@media print {
+  .gem-c-document-list__item-title {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.gem-c-document-list__item-metadata {
+  padding: 0;
+}
+
+.gem-c-document-list__attribute {
+  color: #0b0c0c;
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  font-size: 0.875rem;
+  line-height: 1.1428571429;
+  color: #505a5f;
+  display: inline-block;
+  list-style: none;
+  padding-right: 20px;
+}
+@media print {
+  .gem-c-document-list__attribute {
+    color: #000000;
+  }
+}
+@media print {
+  .gem-c-document-list__attribute {
+    font-family: sans-serif;
+  }
+}
+@media (min-width: 40.0625em) {
+  .gem-c-document-list__attribute {
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+}
+@media print {
+  .gem-c-document-list__attribute {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+@media (min-width: 48.0625em) {
+}
+

--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -1,0 +1,48 @@
+/*
+
+Provide default values for user session data. These are automatically added
+via the `autoStoreData` middleware. Values will only be added to the
+session if a value doesn't already exist. This may be useful for testing
+journeys where users are returning or logging in to an existing application.
+
+============================================================================
+
+Example usage:
+
+"full-name": "Sarah Philips",
+
+"options-chosen": [ "foo", "bar" ]
+
+============================================================================
+
+*/
+
+module.exports = {
+  "highestPageId": 2,
+  "action": "update",
+  "publish": "GOV.UK",
+  "authentication": "email",
+  "payments": "no",
+  "pages": [
+    {
+      "long-title": "What is your name?",
+      "short-title": "name",
+      "hint-text": "Give your name hint",
+      "type": "text",
+      "pageIndex": "0"
+    },
+    {
+      "long-title": "An address question",
+      "short-title": "address",
+      "hint-text": "Just put the address in hint",
+      "type": "address",
+      "pageIndex": "1"
+    }
+  ],
+  "status": "Draft",
+  "confirmationTitle": "Form submitted",
+  "confirmationNext": "We've sent you an email to confirm we have received your form.",
+  "checkAnswersTitle": "Check your answers",
+  "checkAnswersDeclaration": "By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.",
+  "formTitle": "Redundancy payments form: amend my personal details"
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,5 +1,8 @@
+const path = require('path')
 const express = require('express')
 const { setPageIndexToArrayPosition } = require('../lib/utils.js')
+const sessionDataDefaults = require('./data/session-data-defaults.js')
+const returningSessionDataDefaults = require('./data/returning-session-data-defaults')
 const router = express.Router()
 
 // ROUTES FOR EXAMPLE FORMS
@@ -179,6 +182,11 @@ router.post('/form-designer/form-create-a-form', function (req, res) {
   } else {
     res.redirect('form-index')
   }
+})
+
+router.get('/form-designer/returning', (req, res) => {
+  req.session.data = returningSessionDataDefaults 
+  res.redirect('/form-designer/form-list')
 })
 
 

--- a/app/views/form-builder-prototypes.html
+++ b/app/views/form-builder-prototypes.html
@@ -54,6 +54,17 @@
 
           <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
+          <p>
+            <b>
+              <a href="/form-designer/returning">View return journey prototype</a>
+            </b>
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+                      <li>A scenario showing a incomplete form</li>
+                    </ul>
+
+
           <h2 class="govuk-heading-m">
             Form publisher
           </h2>

--- a/app/views/form-designer/form-list.html
+++ b/app/views/form-designer/form-list.html
@@ -5,38 +5,44 @@
 {% endblock %}
 
 {% block content %}
-<h1 class="govuk-heading-l">Your forms</h1>
-<ul class="gem-c-document-list">
-  <li class="gem-c-document-list__item">
-    <a class="gem-c-document-list__item-title govuk-link" href="/form-designer/form-index">{{ data.formTitle }}</a>
-    <ul class="gem-c-document-list__item-metadata">
-      <li class="gem-c-document-list__attribute">
-        <time datetime="2016-06-27T10:29:44+00:00"> 08 May 2022 </time>
-      </li>
-      <li class="gem-c-document-list__attribute"></li>
-    </ul>
-  </li>
+<h1 class="govuk-heading-l">GOV.UK Forms</h1>
 
-  <li class="gem-c-document-list__item">
-    <a class="gem-c-document-list__item-title govuk-link" href="#not-found">Redundancy payments form: amend my claim for holiday taken but not paid</a>
-    <ul class="gem-c-document-list__item-metadata">
-      <li class="gem-c-document-list__attribute">
-        <time datetime="2015-09-24T16:42:48+00:00"> 24 April 2022 </time>
-      </li>
-      <li class="gem-c-document-list__attribute"></li>
-    </ul>
-  </li>
+{{ govukButton({
+    text: "Create a form",
+    classes: "govuk-button--primary",
+    href: "unpublish-confirm"
+}) }}
 
-  <li class="gem-c-document-list__item">
-    <a class="gem-c-document-list__item-title govuk-link" href="#not-found">Redundancy payments form: amend my claim for unpaid wages</a>
-    <ul class="gem-c-document-list__item-metadata">
-      <li class="gem-c-document-list__attribute">
-        <time datetime="2016-09-05T16:48:27+00:00"> 5 April 2022 </time>
-      </li>
-      <li class="gem-c-document-list__attribute">Statutory guidance</li>
-    </ul>
-  </li>
-</ul>
+<h2 class="govuk-heading-m">Your forms</h2>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+    <p class="govuk-body">{{ data.formTitle }}</p>
+      </dt>
+    <dd class="govuk-summary-list__actions">
+      <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/form-index">Edit</a>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+      <p class="govuk-body">Redundancy payments form: amend my claim for holiday taken but not paid</p>
+        </dt>
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--no-visited-state" href="#not-found">Edit</a>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+        <p class="govuk-body">Redundancy payments form: amend my claim for unpaid wages</p>
+          </dt>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="#not-found">Edit</a>
+        </dd>
+      </div>
+
+</dl>
 
 {% endblock %}
 

--- a/app/views/form-designer/form-list.html
+++ b/app/views/form-designer/form-list.html
@@ -1,0 +1,42 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% block pageTitle %}
+  Form list
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-l">Your forms</h1>
+<ul class="gem-c-document-list">
+  <li class="gem-c-document-list__item">
+    <a class="gem-c-document-list__item-title govuk-link" href="/form-designer/form-index">{{ data.formTitle }}</a>
+    <ul class="gem-c-document-list__item-metadata">
+      <li class="gem-c-document-list__attribute">
+        <time datetime="2016-06-27T10:29:44+00:00"> 08 May 2022 </time>
+      </li>
+      <li class="gem-c-document-list__attribute"></li>
+    </ul>
+  </li>
+
+  <li class="gem-c-document-list__item">
+    <a class="gem-c-document-list__item-title govuk-link" href="#not-found">Redundancy payments form: amend my claim for holiday taken but not paid</a>
+    <ul class="gem-c-document-list__item-metadata">
+      <li class="gem-c-document-list__attribute">
+        <time datetime="2015-09-24T16:42:48+00:00"> 24 April 2022 </time>
+      </li>
+      <li class="gem-c-document-list__attribute"></li>
+    </ul>
+  </li>
+
+  <li class="gem-c-document-list__item">
+    <a class="gem-c-document-list__item-title govuk-link" href="#not-found">Redundancy payments form: amend my claim for unpaid wages</a>
+    <ul class="gem-c-document-list__item-metadata">
+      <li class="gem-c-document-list__attribute">
+        <time datetime="2016-09-05T16:48:27+00:00"> 5 April 2022 </time>
+      </li>
+      <li class="gem-c-document-list__attribute">Statutory guidance</li>
+    </ul>
+  </li>
+</ul>
+
+{% endblock %}
+

--- a/lib/prototype-admin/show-data.html
+++ b/lib/prototype-admin/show-data.html
@@ -73,6 +73,12 @@
       </table>
 
     </div>
+    <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-m">
+            Data in JSON format
+          </h2>
+          <pre>{{ data | dump(2) | safe }}</p>
+        </div>
   </div>
 </form>
 


### PR DESCRIPTION
All the design/copy in this commit has been made up to flesh out the pages and can all be changed.

Added a link under the `/form-builder-prototypes` page for a prototype of a return journey. 

The user is shown a list of forms they can edit, using the publishing component document list (for now).

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/11035856/167676214-bec8108c-59b2-4f53-9d4d-175a457062c5.png">

When opening the first link, the data in `app/data/returning-session-data-defaults.js` is loaded into the session and the user is sent to the form overview page, which is populated with the data from the file.

A new section has also been added to the show data page linked in the footer. It shows the json output of the current form, which can be copied into the session file.