### PR TITLE
Add radios and checkboxes back

### DIFF
--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -239,6 +239,14 @@
               value: "phone",
               text: "Phone number",
               checked: checked(namePrefix + "['type']", "phone")
+            },
+            {
+              value: "radio-checkbox",
+              text: "Choosing from a list of options",
+              checked: checked(namePrefix + "['type']", "radio-checkbox"),
+              conditional: {
+              html: radioCheckboxHtml
+            }
             }
           ]
         }) }}

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -248,10 +248,11 @@
                 {{ pageData['hint-text']}}
               </div>
               <div class="govuk-radios">
-                {% for item in itemsArray %}
+                {% for itemRaw in itemsArray %}
+                {% set item = itemRaw | trim %}
                   <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="question-1-{{ item }}" name="question-1-" type="radio" value="{{ item }}">
-                    <label class="govuk-label govuk-radios__label" for="question-1-{{ item }}">
+                    <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}" {{ checked(pageId, item) }}>
+                    <label class="govuk-label govuk-radios__label" for="{{ pageId }}">
                       {{ item }}
                     </label>
                   </div>
@@ -281,10 +282,11 @@
                 {{ pageData['hint-text']}}
               </div>
               <div class="govuk-checkboxes">
-                {% for item in itemsArray %}
+                {% for itemRaw in itemsArray %}
+                  {% set item = itemRaw | trim %}
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="question-1-{{ item }}" name="question-1-" type="checkbox" value="{{ item }}">
-                    <label class="govuk-label govuk-checkboxes__label" for="question-1-{{ item }}">
+                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">
                       {{ item }}
                     </label>
                   </div>

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -208,7 +208,7 @@
         #}
 
         {# Radios #}
-        {# {% if pageData['type'] == 'radio-checkbox' and pageData['radios'] %}
+        {% if pageData['type'] == 'radio-checkbox' and pageData['radios'] %}
 
         {% set itemsArray = pageData['item-list'].split('\n') %}
 
@@ -238,10 +238,10 @@
           </div>
         </fieldset>
         </div>
-        {% endif %} #}
+        {% endif %}
 
         {# Checkboxes #}
-        {# {% if pageData['type'] == 'radio-checkbox' and not pageData['radios'] %}
+        {% if pageData['type'] == 'radio-checkbox' and not pageData['radios'] %}
 
         {% set itemsArray = pageData['item-list'].split('\n') %}
 
@@ -271,7 +271,7 @@
           </div>
         </fieldset>
         </div>
-        {% endif %} #}
+        {% endif %}
 
         {# Help text #}
         {% if pageData['help-text'] %}


### PR DESCRIPTION
Also fix the 'Check your answers' flow for these types.

This will add them back to our prototype screen as well as the CSL deployment. Are we ok with having them in the prototype? If not I'll put them behind a feature flag and only show them in the CSL version.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/11035856/170497769-92fb4c47-db03-4f4f-ac2a-5986c381642a.png">

in the check your answers screen:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/11035856/170497924-5a1c156d-6f70-4286-8c6d-5db561bc4b4f.png">

In the new-tab preview:
<img width="518" alt="image" src="https://user-images.githubusercontent.com/11035856/170498060-81965d80-9e89-4234-a2a5-aa909e47634d.png">

and: 

<img width="451" alt="image" src="https://user-images.githubusercontent.com/11035856/170498119-e5baf3d5-706f-4264-b9ed-52ea90a18bd5.png">

