### PR TITLE
Add more consistent page titles to improve accessibility

### DIFF
--- a/app/views/form-designer/check-answers-page-preview-new-tab.html
+++ b/app/views/form-designer/check-answers-page-preview-new-tab.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  {{data['checkAnswersTitle']}}
+  {{data['checkAnswersTitle']}} - GOV.UK
 {% endblock %}
 
 {% block header %}

--- a/app/views/form-designer/form-create-a-form.html
+++ b/app/views/form-designer/form-create-a-form.html
@@ -2,7 +2,7 @@
 
 
 {% block pageTitle %}
-  {{ "Error:" if containsErrors }} Create a form
+  {{ "Error:" if containsErrors }} What is the name of your form? - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/form-designer/form-home.html
+++ b/app/views/form-designer/form-home.html
@@ -1,7 +1,7 @@
 {% extends "layout-govuk-forms.html" %}
 
 {% block pageTitle %}
-  Form Home
+  GOV.UK Forms
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -1,7 +1,7 @@
 {% extends "layout-govuk-forms.html" %}
 
 {% block pageTitle %}
-  Form: {{ data['formTitle'] }}
+  Form overview: {{ data['formTitle'] }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/form-designer/form-list-a11y.html
+++ b/app/views/form-designer/form-list-a11y.html
@@ -1,7 +1,7 @@
 {% extends "layout-govuk-forms.html" %}
 
 {% block pageTitle %}
-  Form list
+  Form list - GOV.UK Forms
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/form-list.html
+++ b/app/views/form-designer/form-list.html
@@ -1,7 +1,7 @@
 {% extends "layout-govuk-forms.html" %}
 
 {% block pageTitle %}
-  Form list
+  GOV.UK Forms
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  Edit question
+  {{ pageData['long-title'] }} - GOV.UK
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Closes #64 

In keeping with the initial proposal on #64 and the subsequent comments, this changes the page titles on the prototype as follows:
- Form builder home screen: 
  - Current title: 'Form home'
  - New title 'GOV.UK Forms'
- Form naming screen
  - Current title: 'Create a form'
  - New title 'What is the name of your form? - GOV.UK Forms'
- Form overview screen
  - Current title: 'Form: {form title}'
  - New title 'Form overview: {form title} - GOV.UK Forms'
- Create/Edit question page
  - Current title: Uses the question title, e.g. 'What is your name?'
  - New title '{question title} - GOV.UK Forms'
- New tab preview pages:
  - Current title: 'Edit question'
  - New title '{question title} - GOV.UK'

This should make it easier for users of some assistive technologies to navigate the prototype.