### PR TITLE
Change continue button text on last page

### DIFF
--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -22,7 +22,6 @@
   {% set nextPageId = pageId | int + 1 %}
   {% set isLastQuestionPage = pageId == data['highestPageId'] %}
   {% set formAction = "../check-answers-page-preview-new-tab" if isLastQuestionPage else nextPageId %}
-  {% set buttonText = "Check your answers" if isLastQuestionPage else "Continue" %}
 
   <form class="form" action='{{formAction}}' method="post">
     <div class="govuk-grid-row">
@@ -314,7 +313,7 @@
         {% endif %}
 
         {{ govukButton({
-          text: buttonText,
+          text: "Continue",
           attributes: {
             target: "_parent"
           }


### PR DESCRIPTION
The last page of the new-tab preview submit button says "Check your answers".

It's been changed to "Continue"

Old:
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/11035856/175027729-22cc087c-d175-4ace-aea4-97e0f575e5e6.png">


New:
<img width="1291" alt="image" src="https://user-images.githubusercontent.com/11035856/175027569-4c12c7ef-364e-46d5-b582-959977ed20fd.png">
