### PR TITLE
Move hint-text out of conditional-reveal

### DIFF
--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -137,28 +137,19 @@
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details" {{"open" if pageData['hint-text']}}>
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Add hint text to help people answer the question
-            </span>
-          </summary>
-          <div class="govuk-details__text govuk-!-padding-bottom-0">
-            {{ govukInput({
-              label: {
-                text: "Hint text (optional)",
-                classes: "govuk-visually-hidden"
-              },
-              hint: {
-                text: "You can use hint text if you need to explain the format the answer should be in, or where to find the information you’ve asked for."
-              },
-              id: "hint-text",
-              name: namePrefix + "[hint-text]",
-              value: pageData['hint-text']
-            }) }}
-          </div>
-        </details>
-
+        {{ govukInput({
+          label: {
+            text: "Hint text (optional)",
+            classes: "govuk-label--m"
+          },
+          hint: {
+            text: "You can use hint text if you need to explain the format the answer should be in, or where to find the information you’ve asked for."
+          },
+          id: "hint-text",
+          name: namePrefix + "[hint-text]",
+          value: pageData['hint-text']
+        }) }}
+      
         {# <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">


### PR DESCRIPTION
On the edit page screen, the hint-text option should always be visible.

Kept the HR in.

Old:
<img width="688" alt="image" src="https://user-images.githubusercontent.com/11035856/175066595-ad1df23c-e3db-4207-a7f7-3dd8e9e2e029.png">

New:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/11035856/175066664-8231f048-b28d-4e47-b778-c57bb2a6306c.png">
