### PR TITLE
Remove back button from first question in preview

### DIFF
--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -9,8 +9,6 @@
   {% set prevPageId = pageId | int - 1 %}
   {% if prevPageId > 0 %}
     <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
-  {% else %}
-    <a class="govuk-back-link" href="../start-page-preview-new-tab" target="_parent">Back</a>
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Previous:
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/11035856/175072034-fd872d87-1f37-4ed3-8d3e-f7c5bde5fcd9.png">

Current:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/11035856/175072112-65f1185c-c612-4ae8-ae68-983bf043bb08.png">
