### PR TITLE
Remove short-name input field

### DIFF
--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -25,6 +25,7 @@ module.exports = {
   "payments": "no",
   "pages": [
     {
+      "intro": "This is the intro",
       "long-title": "What is you name?",
       "short-title": "Name",
       "hint-text": "Enter your fuul name",

--- a/app/views/form-designer/check-answers-page-preview-new-tab.html
+++ b/app/views/form-designer/check-answers-page-preview-new-tab.html
@@ -23,7 +23,7 @@
   <dl class="govuk-summary-list">
     {% for page in data.pages -%}
 
-      {% set questionTitle = page["short-title"]  or page["long-title"] or "Page " + page["pageIndex"] %}
+      {% set questionTitle = page["long-title"] or "Page " + page["pageIndex"] %}
 
       {% if questionTitle %}
 

--- a/app/views/form-designer/check-answers-page-preview.html
+++ b/app/views/form-designer/check-answers-page-preview.html
@@ -17,7 +17,7 @@
     <dl class="govuk-summary-list">
       {% for page in data.pages -%}
 
-        {% set questionTitle = page["short-title"]  or page["long-title"] or "Page " + page["pageIndex"] %}
+        {% set questionTitle = page["long-title"] or "Page " + page["pageIndex"] %}
 
         {% if questionTitle %}
           <div class="govuk-summary-list__row">

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -121,20 +121,6 @@
           value: pageData['long-title']
         }) }}
 
-        <!-- Short question text input -->
-        {{ govukInput({
-          label: {
-            text: "Question short name (optional)",
-            classes: "govuk-label--m"
-          },
-          hint: {
-            text: "The short name will be used when the form’s questions are all displayed in a list. Use a short descriptive name. For example ‘Address’."
-          },
-          id: "short-title",
-          name: namePrefix + "[short-title]",
-          value: pageData['short-title']
-        }) }}
-
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details" {{"open" if pageData['hint-text']}}>

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -34,22 +34,6 @@
 
         #}
 
-        {% if pageData['intro-text'] %}
-
-          {# If the page has an intro, set the heading outside of the macros #}
-          {# Use the short title as the field label #}
-          <h1 class="govuk-heading-l">{{ pageData['long-title'] }}</h1>
-          <div class="app-prose-scope">
-            {% markdown %}
-            {{ pageData['intro-text'] }}
-            {% endmarkdown %}
-          </div>
-          {% set label = {
-            text: pageData['short-title']
-          }%}
-
-        {% else %}
-
           {# If the page has no intro, set the heading inside of the macros #}
           {# The heading doubles up as the label #}
           {% set label = {
@@ -57,8 +41,6 @@
             classes: "govuk-label--l",
             isPageHeading: true
           }%}
-
-        {% endif %}
 
         {# Single line text fields #}
         {% if pageData['type'] == 'text' %}

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -21,33 +21,13 @@
 
         #}
 
-        {% if pageData['intro-text'] %}
-
-          {# If the page has an intro, set the heading outside of the macros #}
-          {# Use the short title as the field label #}
-          <h1 class="govuk-heading-l">{{ pageData['long-title'] }}</h1>
-
-          <div class="app-prose-scope">
-            {% markdown %}
-            {{ pageData['intro-text'] }}
-            {% endmarkdown %}
-          </div>
-
-          {% set label = {
-            text: pageData['short-title']
-          }%}
-
-        {% else %}
-
-          {# If the page has no intro, set the heading inside of the macros #}
-          {# The heading doubles up as the label #}
-          {% set label = {
-            text: pageData['long-title'],
-            classes: "govuk-label--l",
-            isPageHeading: true
-          }%}
-
-        {% endif %}
+        {# If the page has no intro, set the heading inside of the macros #}
+        {# The heading doubles up as the label #}
+        {% set label = {
+          text: pageData['long-title'],
+          classes: "govuk-label--l",
+          isPageHeading: true
+        }%}
 
         {# Single line text fields #}
         {% if pageData['type'] == 'text' %}


### PR DESCRIPTION
Short name has been removed from the edit-question page and is no longer
used in any of the other pages.

The biggest visited change is in the CYA page, which used short name as
a heading for questions to be changed.

Short name was also used on pages with intro text (a feature that has
also been removed).

The best way to add short-name back to the prototype would be to revert
this commit.

Previous:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/11035856/175081417-d04730f1-219c-451d-8cb1-76f8d13a5636.png">

New:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/11035856/175081516-7d6aeb91-c665-4226-9763-636720398e8c.png">


URL's in the prototype haven't been altered to using the question stripped of spaces and punctuation as it would require a bigger change.