### PR TITLE
Add 'number' answer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Form designer views: [/app/views/form-designer](https://github.com/alphagov/form
 
 ## Environment variables
 
+Set these environment variables to `true` to enable the features.
+
 | Name                                 | Purpose                                             |
 | ------------------------------------ | --------------------------------------------------- |
 | `ENABLE_MULTIPLE_CHOICE_ANSWER_TYPE` | Feature flag to enable multiple choice answer types |
+| `ENABLE_NUMBER_ANSWER_TYPE`          | Feature flag to enable numeric answer type          |

--- a/app/routes.js
+++ b/app/routes.js
@@ -55,6 +55,9 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
   var enableMultipleChoiceAnswerType =
     process.env.ENABLE_MULTIPLE_CHOICE_ANSWER_TYPE === 'true'
 
+  var enableNumberAnswerType =
+    process.env.ENABLE_NUMBER_ANSWER_TYPE === 'true'
+
   // Update the 'Highest page Id'
   req.session.data.highestPageId = req.session.data.pages.length
   var createNextPageId = parseInt(req.session.data.highestPageId) + 1
@@ -108,7 +111,8 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
       pageIndex: pageIndex,
       pageData: pageData,
       editingExistingQuestion: req.session.data.pages[pageIndex] !== undefined,
-      enableMultipleChoiceAnswerType
+      enableMultipleChoiceAnswerType,
+      enableNumberAnswerType
     })
   }
 })

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -181,6 +181,11 @@
               checked: checked(namePrefix + "['type']", "text") or allEmpty
             },
             {
+              value: "text",
+              text: "Number",
+              checked: checked(namePrefix + "['type']", "text") or allEmpty
+            } if enableNumberAnswerType,
+            {
               value: "address",
               text: "Address",
               checked: checked(namePrefix + "['type']", "address")


### PR DESCRIPTION
During demonstrations we often have questions which could best be
answered with a number. The prototype originally had a numeric answer
type but it was removed to suport user testing sessions which did not
require it.

A feature flag has been added to enable a number answer type which
behaves like the short-text type.

To test it, start the prototype with the following command:

`ENABLE_NUMBER_ANSWER_TYPE=true npm run start`

With the feature enabled:
<img width="650" alt="image" src="https://user-images.githubusercontent.com/11035856/175295567-5e188b0d-b6f6-45f4-af01-29e3bf50bcf9.png">

Without the feature enabled:
<img width="655" alt="image" src="https://user-images.githubusercontent.com/11035856/175295745-707debec-4b87-484b-bc08-0211689e8a2b.png">
