### PR TITLE
Add 'restore default form data' link to footer

### DIFF
--- a/app/data/returning-session-data-defaults-a11y.js
+++ b/app/data/returning-session-data-defaults-a11y.js
@@ -18,57 +18,59 @@ Example usage:
 */
 
 module.exports = {
-  "highestPageId": 2,
-  "action": "update",
-  "publish": "GOV.UK",
-  "authentication": "email",
-  "payments": "no",
-  "pages": [
+  highestPageId: 6,
+  action: 'update',
+  publish: 'GOV.UK',
+  authentication: 'email',
+  payments: 'no',
+  pages: [
     {
-      "long-title": "What type animal is pet?",
-      "short-title": "Animal type",
-      "hint-text": "For example a bird, a hat.",
-      "type": "text",
-      "pageIndex": "0"
+      'long-title': 'What type animal is pet?',
+      'short-title': 'Animal type',
+      'hint-text': 'For example a bird, a hat.',
+      type: 'text',
+      pageIndex: '0'
     },
     {
-      "long-title": "What is the name of your pet?",
-      "short-title": "Pet name",
-      "type": "text",
-      "pageIndex": "1"
+      'long-title': 'What is the name of your pet?',
+      'short-title': 'Pet name',
+      type: 'text',
+      pageIndex: '1'
     },
     {
-      "long-title": "Where are you travelling to?",
-      "short-title": "Destination",
-      "hint-text": "For example Lisbon, Portugal",
-      "type": "text",
-      "pageIndex": "2"
+      'long-title': 'Where are you travelling to?',
+      'short-title': 'Destination',
+      'hint-text': 'For example Lisbon, Portugal',
+      type: 'text',
+      pageIndex: '2'
     },
     {
-      "long-title": "What date do you travel?",
-      "short-title": "Date",
-      "hint-text": "For example 27 3 2007",
-      "type": "address",
-      "pageIndex": "3"
+      'long-title': 'What date do you travel?',
+      'short-title': 'Date',
+      'hint-text': 'For example 27 3 2007',
+      type: 'address',
+      pageIndex: '3'
     },
     {
-      "long-title": "What transport means are you using?",
-      "short-title": "Transport type",
-      "hint-text": "For example plane, train, car.",
-      "type": "date",
-      "pageIndex": "4"
+      'long-title': 'What transport means are you using?',
+      'short-title': 'Transport type',
+      'hint-text': 'For example plane, train, car.',
+      type: 'date',
+      pageIndex: '4'
     },
     {
-      "long-title": "How many pets do you have",
-      "short-title": "How many pets",
-      "type": "text",
-      "pageIndex": "5"
+      'long-title': 'How many pets do you have',
+      'short-title': 'How many pets',
+      type: 'text',
+      pageIndex: '5'
     }
   ],
-  "status": "Draft",
-  "confirmationTitle": "Form submitted",
-  "confirmationNext": "We've sent you an email to confirm we have received your form.",
-  "checkAnswersTitle": "Check your answers",
-  "checkAnswersDeclaration": "By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.",
-  "formTitle": "Take your pet abroad"
+  status: 'Draft',
+  confirmationTitle: 'Form submitted',
+  confirmationNext:
+    "We've sent you an email to confirm we have received your form.",
+  checkAnswersTitle: 'Check your answers',
+  checkAnswersDeclaration:
+    'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',
+  formTitle: 'Take your pet abroad'
 }

--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -18,59 +18,61 @@ Example usage:
 */
 
 module.exports = {
-  "highestPageId": 5,
-  "action": "update",
-  "publish": "GOV.UK",
-  "authentication": "email",
-  "payments": "no",
-  "pages": [
+  highestPageId: 6,
+  action: 'update',
+  publish: 'GOV.UK',
+  authentication: 'email',
+  payments: 'no',
+  pages: [
     {
-      "intro": "This is the intro",
-      "long-title": "What is you name?",
-      "short-title": "Name",
-      "hint-text": "Enter your fuul name",
-      "type": "text",
-      "pageIndex": "0"
+      intro: 'This is the intro',
+      'long-title': 'What is you name?',
+      'short-title': 'Name',
+      'hint-text': 'Enter your fuul name',
+      type: 'text',
+      pageIndex: '0'
     },
     {
-      "long-title": "What is your claim reference number?",
-      "short-title": "Claim reference number",
-      "hint-text": "Begings with LN",
-      "type": "text",
-      "pageIndex": "1"
+      'long-title': 'What is your claim reference number?',
+      'short-title': 'Claim reference number',
+      'hint-text': 'Begings with LN',
+      type: 'text',
+      pageIndex: '1'
     },
     {
-      "long-title": "What is your national insurance number?",
-      "short-title": "National Insurance number",
-      "hint-text": "For example QQ12345C",
-      "type": "text",
-      "pageIndex": "2"
+      'long-title': 'What is your national insurance number?',
+      'short-title': 'National Insurance number',
+      'hint-text': 'For example QQ12345C',
+      type: 'text',
+      pageIndex: '2'
     },
     {
-      "long-title": "What is your date of bitrh?",
-      "short-title": "Date of Bitrh",
-      "hint-text": "For example 27 3 2007",
-      "type": "address",
-      "pageIndex": "3"
+      'long-title': 'What is your date of bitrh?',
+      'short-title': 'Date of Bitrh',
+      'hint-text': 'For example 27 3 2007',
+      type: 'address',
+      pageIndex: '3'
     },
     {
-      "long-title": "When did you submit your redundancy claim?",
-      "short-title": "Claim submitted",
-      "hint-text": "For example 27 3 2007",
-      "type": "date",
-      "pageIndex": "4"
+      'long-title': 'When did you submit your redundancy claim?',
+      'short-title': 'Claim submitted',
+      'hint-text': 'For example 27 3 2007',
+      type: 'date',
+      pageIndex: '4'
     },
     {
-      "long-title": "What is your adress?",
-      "short-title": "Address",
-      "type": "date",
-      "pageIndex": "5"
+      'long-title': 'What is your adress?',
+      'short-title': 'Address',
+      type: 'date',
+      pageIndex: '5'
     }
   ],
-  "status": "Draft",
-  "confirmationTitle": "Form submitted",
-  "confirmationNext": "We've sent you an email to confirm we have received your form.",
-  "checkAnswersTitle": "Check your answers",
-  "checkAnswersDeclaration": "By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.",
-  "formTitle": "Redundancy payments form: amend my personal details"
+  status: 'Draft',
+  confirmationTitle: 'Form submitted',
+  confirmationNext:
+    "We've sent you an email to confirm we have received your form.",
+  checkAnswersTitle: 'Check your answers',
+  checkAnswersDeclaration:
+    'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',
+  formTitle: 'Redundancy payments form: amend my personal details'
 }

--- a/app/views/layout-govuk-forms.html
+++ b/app/views/layout-govuk-forms.html
@@ -67,6 +67,10 @@
           {
             href: "/prototype-admin/clear-data",
             text: "Clear data"
+          },
+          {
+            href: "/form-designer/returning",
+            text: "Restore default form data"
           }
         ]
       }


### PR DESCRIPTION
This change adds a 'restore default form data' link to the footer, which links to the return journey flow. This should make it easier to resolve the situation in research sessions where the user's data isn't reset for the return journey testing.

Also includes a small change to the return session data to prevent a bug - without this change the 'Add question' button will take you to edit one of the existing questions. the change looks bigger than it is because the files have been formatted.
![Screenshot 2022-06-24 at 12 21 13](https://user-images.githubusercontent.com/5861235/175524722-f6caac64-eeb8-4cd7-b2e0-a5900b97034b.png)

