### PR TITLE
Add dummy text to non-completed answers

### DIFF
--- a/app/views/form-designer/check-answers-page-preview-new-tab.html
+++ b/app/views/form-designer/check-answers-page-preview-new-tab.html
@@ -34,7 +34,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
 
-          {% if (data[loop.index]) or data[loop.index + '-year'] %}
+          {% if (data[loop.index]) or (data[loop.index + '-year']) %}
             {% if page['type'] == 'date' %}
               {{data[loop.index + '-day']}}
               {% if (data[loop.index + '-day']) %}/{% endif %}

--- a/app/views/form-designer/check-answers-page-preview-new-tab.html
+++ b/app/views/form-designer/check-answers-page-preview-new-tab.html
@@ -33,22 +33,27 @@
           <!--Q{{page["pageIndex"] | int + 1}}.--> {{questionTitle}}
         </dt>
         <dd class="govuk-summary-list__value">
-          {% if page['type'] == 'date' %}
-            {{data[loop.index + '-day']}}
-            {% if (data[loop.index + '-day']) %}/{% endif %}
-            {{data[loop.index + '-month'] or '01'}} / {{data[loop.index + '-year']}}
-          {% elif page['type'] == 'address' %}
-            {{data[loop.index + '-address-line-1']}}<br>
-            {% if data[loop.index + '-address-line-2'] %}{{data[loop.index + '-address-line-2']}}<br>{% endif %}
-            {{data[loop.index + '-address-town']}}<br>
-            {{data[loop.index + '-address-postcode']}}
+
+          {% if (data[loop.index]) or data[loop.index + '-year'] %}
+            {% if page['type'] == 'date' %}
+              {{data[loop.index + '-day']}}
+              {% if (data[loop.index + '-day']) %}/{% endif %}
+              {{data[loop.index + '-month'] or '01'}} / {{data[loop.index + '-year']}}
+            {% elif page['type'] == 'address' %}
+              {{data[loop.index + '-address-line-1']}}<br>
+              {% if data[loop.index + '-address-line-2'] %}{{data[loop.index + '-address-line-2']}}<br>{% endif %}
+              {{data[loop.index + '-address-town']}}<br>
+              {{data[loop.index + '-address-postcode']}}
+            {% else %}
+              {{data[loop.index]}}
+            {% endif %}
           {% else %}
-            {{data[loop.index]}}
+            Not completed
           {% endif %}
         </dd>
           <dd class="govuk-summary-list__actions">
               <a class="govuk-link govuk-link--no-visited-state" href="page-preview-new-tab/{{loop.index}}">
-                Change
+                Change <span class="govuk-visually-hidden">{{questionTitle}}<span>
               </a>
           </dd>
       </div>


### PR DESCRIPTION
Closes #92 

Adds 'Not completed' text if the user hasn't answered the question in the preview.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5861235/176430521-2310a28d-384f-40c4-acff-437ec3eab100.png)

### After
![image](https://user-images.githubusercontent.com/5861235/176430589-1d5039fe-4c13-4ad9-8b8e-c23d2e47be72.png)
