### PR TITLE
Fix number type being selected in CSL

### DIFF
--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -166,6 +166,7 @@
         {# If no type is set, set type to text #}
         {%
          set allEmpty = not (checked(namePrefix + "['type']", "text")
+           or checked(namePrefix + "['type']", "number")
            or checked(namePrefix + "['type']", "email")
            or checked(namePrefix + "['type']", "address")
            or checked(namePrefix + "['type']", "phone")
@@ -181,9 +182,9 @@
               checked: checked(namePrefix + "['type']", "text") or allEmpty
             },
             {
-              value: "text",
+              value: "number",
               text: "Number",
-              checked: checked(namePrefix + "['type']", "text") or allEmpty
+              checked: checked(namePrefix + "['type']", "number")
             } if enableNumberAnswerType,
             {
               value: "address",

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -52,6 +52,17 @@
           }) }}
         {% endif %}
 
+        {# Number fields #}
+        {% if pageData['type'] == 'number' %}
+          {{ govukInput({
+            label: label,
+            hint: {text: pageData['hint-text']},
+            id: pageId,
+            name: pageId,
+            value: data[pageId | int]
+          }) }}
+        {% endif %}
+
         {% if pageData['type'] == 'email' %}
           {{ govukInput({
           label: label,

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -37,29 +37,15 @@
           id: pageId,
           name: pageId
         }) }}
+        {% endif %}
 
-          {# Currency fields #}
-        {% elseif pageData['type'] == 'text' and pageData['unit'] == 'pounds' %}
+        {# Number text fields #}
+        {% if pageData['type'] == 'number' %}
           {{ govukInput({
           label: label,
           hint: {text: pageData['hint-text']},
           id: pageId,
-          name: pageId,
-          prefix: {text: "£"},
-          classes: "govuk-input--width-5",
-          spellcheck: false
-        }) }}
-
-          {# Weight, distance and length fields #}
-        {% elseif pageData['type'] == 'text'  %}
-          {{ govukInput({
-          label: label,
-          hint: {text: pageData['hint-text']},
-          id: pageId,
-          name: pageId,
-          suffix: {text: pageData['unit']},
-          classes: "govuk-input--width-5",
-          spellcheck: false
+          name: pageId
         }) }}
         {% endif %}
 


### PR DESCRIPTION
In CSL demos the answer type 'number' is the default selection for new questions.

This is because it was copied from the text type and uses the same logic to show that it's checked. Because it comes after the text type, it's always going to get selected.

This is fixed by introducing a new answer type 'number' and re-using the text code to display it in the previews.