### PR TITLE
Add "set email" journey w/ basic error checking. Inc form overview links

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -251,7 +251,7 @@ router.post('/form-designer/completed-forms-email/set-completed-forms-email', fu
 
   // If the formsEmail is blank, create an error to be displayed to the user
   if (!formsEmail?.length) {
-    errors['formsEmail'] = {
+    errors.formsEmail = {
       text: 'Enter an email address where form submissions should be sent',
       href: "#forms-email"
     }

--- a/app/routes.js
+++ b/app/routes.js
@@ -241,4 +241,66 @@ router.get('/form-designer/returning', (req, res) => {
   res.redirect('/form-designer/form-list-a11y')
 })
 
+
+// Routing for publishing steps
+
+// Renders the page which asks for form submissions email address, handling validation errors
+router.post('/form-designer/completed-forms-email/set-completed-forms-email', function (req, res) {
+  const errors = {};
+  const { formsEmail } = req.session.data
+  const { currentFormsEmail } = req.session.data
+
+  // If the formsEmail is blank, create an error to be displayed to the user
+  if (!formsEmail || !formsEmail.length) {
+    errors['formsEmail'] = {
+      text: 'Enter an email address where form submissions should be sent',
+      href: "#forms-email"
+    }
+  }
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  if(containsErrors) {
+    res.render('form-designer/completed-forms-email/set-completed-forms-email', { errors, errorList, containsErrors })
+  } else {
+    if(currentFormsEmail && (currentFormsEmail != formsEmail)) {
+      res.redirect('change-email-address')
+    } else {
+      res.redirect('confirmation-code-sent')
+    }
+  }
+})
+
+// Renders the page which asks to confirm wanting to change submission email address, handling validation errors
+router.post('/form-designer/completed-forms-email/change-email-address', function (req, res) {
+  const errors = {};
+  const { changeFormsEmail } = req.session.data
+
+  // If the changeFormsEmail has selection, create an error to be displayed to the user
+  if (!changeFormsEmail || !changeFormsEmail.length) {
+    errors['formsEmail'] = {
+      text: 'Select yes if you want to change the email',
+      href: "#forms-email"
+    }
+  }
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  if(containsErrors) {
+    res.render('form-designer/completed-forms-email/change-email-address', { errors, errorList, containsErrors })
+  } else {
+    if(changeFormsEmail == 'yes') {
+      res.redirect('confirmation-code-sent')
+    } else {
+      res.redirect('set-completed-forms-email')
+    }
+  }
+})
+
 module.exports = router

--- a/app/routes.js
+++ b/app/routes.js
@@ -250,7 +250,7 @@ router.post('/form-designer/completed-forms-email/set-completed-forms-email', fu
   const { formsEmail, currentFormsEmail } = req.session.data
 
   // If the formsEmail is blank, create an error to be displayed to the user
-  if (!formsEmail || !formsEmail.length) {
+  if (!formsEmail?.length) {
     errors['formsEmail'] = {
       text: 'Enter an email address where form submissions should be sent',
       href: "#forms-email"

--- a/app/routes.js
+++ b/app/routes.js
@@ -294,7 +294,7 @@ router.post('/form-designer/completed-forms-email/change-email-address', functio
   if(containsErrors) {
     res.render('form-designer/completed-forms-email/change-email-address', { errors, errorList, containsErrors })
   } else {
-    if(changeFormsEmail == 'yes') {
+    if(changeFormsEmail === 'yes') {
       res.redirect('confirmation-code-sent')
     } else {
       res.redirect('set-completed-forms-email')

--- a/app/routes.js
+++ b/app/routes.js
@@ -247,8 +247,7 @@ router.get('/form-designer/returning', (req, res) => {
 // Renders the page which asks for form submissions email address, handling validation errors
 router.post('/form-designer/completed-forms-email/set-completed-forms-email', function (req, res) {
   const errors = {};
-  const { formsEmail } = req.session.data
-  const { currentFormsEmail } = req.session.data
+  const { formsEmail, currentFormsEmail } = req.session.data
 
   // If the formsEmail is blank, create an error to be displayed to the user
   if (!formsEmail || !formsEmail.length) {

--- a/app/views/form-designer/completed-forms-email/change-email-address.html
+++ b/app/views/form-designer/completed-forms-email/change-email-address.html
@@ -1,0 +1,62 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Are you sure you want to change this email address?' %}
+
+{% block pageTitle %}
+  {{ "Error:" if containsErrors }}{{pageTitle|safe}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="{{data['referer']}}">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if containsErrors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{pageTitle|safe}}</h1>
+
+      <p class="govuk-body">
+        Completed forms will be sent to {{data['formsEmail'] or 'first.email@address.com' | safe}} instead of {{data['currentFormsEmail'] or 'second.email@address.com' | safe}}.
+      </p>
+
+      <form method="post">
+
+        {{ govukRadios({
+          idPrefix: "change-email-yesno",
+          name: "changeFormsEmail",
+          fieldset: {
+            legend: {
+              text: pageTitle|safe,
+              classes: "govuk-visually-hidden"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              checked: data['change-email-yesno'] == 'yes'
+            },
+            {
+              value: "no",
+              text: "No",
+              checked: data['change-email-yesno'] == 'no'
+            }
+          ],
+          errorMessage: { text: errors['changeFormsEmail'].text } if errors['changeFormsEmail'].text
+        }) }}
+
+        <button type="submit" class="govuk-button">Continue</button>
+      </form>
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
+++ b/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
@@ -1,0 +1,35 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Confirmation code sent' %}
+
+{% block pageTitle %}
+  {{pageTitle|safe}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="{{data['referer']}}">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{pageTitle|safe}}</h1>
+
+      <p class="govuk-body">
+        We've sent a confirmation code and your email address to {{data['formsEmail'] or 'email@address.com' | safe}}. The recipient will be asked to give you the code. You need to enter the code to confirm the email address. The code is valid for 7 days.
+      </p>
+
+      <p class="govuk-body">
+         <a href="add-confirmation-code" class="govuk-link">Enter the email address confirmation code</a>
+      </p>
+
+      <p class="govuk-body">
+        <a href="../form-index" class="govuk-link">Go to form overview</a>
+      </p>
+
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/form-designer/completed-forms-email/set-completed-forms-email.html
+++ b/app/views/form-designer/completed-forms-email/set-completed-forms-email.html
@@ -1,0 +1,57 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Set the email address for completed forms' %}
+
+{% block pageTitle %}
+  {{ "Error:" if containsErrors }}{{pageTitle|safe}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="../form-index">Back to form overview</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if containsErrors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">{{pageTitle|safe}}</h1>
+
+      <p class="govuk-body">
+        This should be a shared government email inbox.
+      </p>
+
+      <p class="govuk-body">
+        An email will be sent to this address with a confirmation code and your email address. The recipient will be asked to tell you the code. You will then need to enter the code to confirm the email address.
+      </p>
+
+      <form method="post">
+
+        {{ govukInput({
+          label: {
+            text: "What email address should completed forms be sent to?",
+            classes: "govuk-label--m"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "forms-email",
+          name: "formsEmail",
+          errorMessage: { text: errors['formsEmail'].text } if errors['formsEmail'].text
+        }) }}
+
+        {% if not data['currentFormsEmail'] or data['currentFormsEmail'] == '' %}
+          <input type="hidden" name="currentFormsEmail" value="{{data['currentFormsEmail'] or data['formsEmail']}}">
+        {% endif %}
+
+        <button type="submit" class="govuk-button">Continue</button>
+      </form>
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -21,26 +21,24 @@
         {% set nextPageId = data['highestPageId'] | int + 1 %}
         {% set totalPageNum = data['highestPageId'] | int + 2 %}
 
-      {{ govukButton({
+        {{ govukButton({
           text: "Add a question",
           href: "choose-page-type/" + nextPageId,
           classes: "govuk-!-margin-bottom-3 govuk-!-margin-top-3"
         }) }}
 
-
-
         <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Form name</h2>
 
         <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-          {{ data['formTitle'] }}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+              {{ data['formTitle'] }}
             </dt>
-          <dd class="govuk-summary-list__actions">
-            <a class="govuk-link govuk-link--no-visited-state" href="form-create-a-form.html"> Edit</a>
-          </dd>
-        </div>
-      </dl>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link govuk-link--no-visited-state" href="form-create-a-form.html">Edit<span class="govuk-visually-hidden"> form name</span></a>
+            </dd>
+          </div>
+        </dl>
 
       {% if data.pages.length %}
 
@@ -78,9 +76,8 @@
                     {% endif %}
                     <div>
 
-                    <a class="govuk-link govuk-link--no-visited-state"
-                    href="edit-page/{{page.pageIndex | int + 1}}">
-                      Edit <span class="govuk-visually-hidden">{{questionTitle}}</span>
+                    <a class="govuk-link govuk-link--no-visited-state"href="edit-page/{{page.pageIndex | int + 1}}">
+                      Edit<span class="govuk-visually-hidden"> {{questionTitle}}</span>
                     </a>
                   </div>
                 </dd>
@@ -92,43 +89,51 @@
 
           <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Standard pages</h2>
           <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-            <p>Check your answers</p>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+                <p>Check your answers</p>
                 <p class="govuk-hint">This page lists all the questions and answers so people can check them before they submit the form. You can add a declaration for people to confirm their answers.</p>
               </dt>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link govuk-link--no-visited-state" href="edit-page/check-answers">
-                      Edit</a>
-            </dd>
-          </div>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-page/check-answers">
+                  Edit<span class="govuk-visually-hidden"> check your answers page</span>
+                </a>
+              </dd>
+            </div>
 
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-            <p>Confirmation</p>
-            <p class="govuk-hint">This page will be shown to confirm the form has been submitted. You can add information to tell people what will happen next.</p>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
+                <p>Form submitted</p>
+                <p class="govuk-hint">This page will be shown to confirm the form has been submitted. You can add information to tell people what will happen next.</p>
               </dt>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link govuk-link--no-visited-state" href="edit-page/confirmation">
-                      Edit</a>
-            </dd>
-          </div>
-        </dl>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-page/confirmation">
+                  Edit<span class="govuk-visually-hidden"> form submitted page</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
 
-      <div class="govuk-!-margin-top-9">
-        <h2 class="govuk-heading-m">Next steps</h2>
-        <p><a href="/form-designer/page-preview-new-tab/1" target="_blank">Test the form in a new tab</a></p>
-        {{ govukButton({
-            text: "Publish form",
-            classes: "govuk-button--secondary",
-            href: "form-publish"
-          }) }}
-      </div>
-      {% endif %}
+          <div class="govuk-!-margin-top-9">
+            <h2 class="govuk-heading-m">Next steps</h2>
+            <p class="govuk-body">
+              <a href="/form-designer/page-preview-new-tab/1" target="_blank">Preview the form in a new tab</a>
+            <p>
+            <p class="govuk-body">
+              <a href="completed-forms-email/set-completed-forms-email">Set the email address completed forms will be sent to</a>
+            </p>
+            <p>
+            <p class="govuk-body">
+              <a href="completed-forms-email/add-confirmation-code">Enter the email address confirmation code</a>
+            </p>
+            <p class="govuk-body">
+              <a href="form-publish">Get your form live on GOV.UK</a>
+            </p>
+          </div>
+        {% endif %}
       </div>
 
     </div>
-
   </form>
 
 {% endblock %}


### PR DESCRIPTION
This covers work required on https://github.com/alphagov/forms-prototypes/issues/98 

Includes 3 new pages:

- Set the email address for completed forms
- Are you sure you want to change this email address?
- Confirmation code sent

Added links to new journeys from form overview screen, and updated links to align with [MURAL](https://app.mural.co/t/gaap0347/m/gaap0347/1652697480711/fa60d6e36c472088d3c49ea4a7e7fc5b1d8186d4?wid=0-1657612670722)

Basic validation checks and errors for empty input or no radio selected.

Where user has entered an email before (in the same session) when they return to "Set the email address for completed forms" page and put a different email in they will be redirected to the "Are you sure you want to change this email address?" page. 