### PR TITLE
103 design add content about what happens next to a confirmation page

### DIFF
--- a/app/data/returning-session-data-defaults-a11y.js
+++ b/app/data/returning-session-data-defaults-a11y.js
@@ -66,9 +66,8 @@ module.exports = {
     }
   ],
   status: 'Draft',
-  confirmationTitle: 'Form submitted',
-  confirmationNext:
-    "We've sent you an email to confirm we have received your form.",
+  confirmationTitle: 'Your form has been submitted',
+  confirmationNext:'',
   checkAnswersTitle: 'Check your answers',
   checkAnswersDeclaration:
     'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',

--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -68,9 +68,8 @@ module.exports = {
     }
   ],
   status: 'Draft',
-  confirmationTitle: 'Form submitted',
-  confirmationNext:
-    "We've sent you an email to confirm we have received your form.",
+  confirmationTitle: 'Your form has been submitted',
+  confirmationNext: '',
   checkAnswersTitle: 'Check your answers',
   checkAnswersDeclaration:
     'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -28,8 +28,8 @@ module.exports = {
   payments: 'no',
   pages: [],
   status: 'Draft',
-  confirmationTitle: 'Form submitted',
-  confirmationNext: "We've sent you an email to confirm we have received your form.",
+  confirmationTitle: 'Your form has been submitted',
+  confirmationNext: '',
   checkAnswersTitle: 'Check your answers',
   checkAnswersDeclaration: 'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.'
 }

--- a/app/views/form-designer/confirmation-page-preview-new-tab.html
+++ b/app/views/form-designer/confirmation-page-preview-new-tab.html
@@ -15,10 +15,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">{{data['confirmationTitle']}} <span class="govuk-visually-hidden">preview</span></h1>
-      <div class="govuk-panel__body">
-        Your reference number is<br><strong>HDJ2123F</strong>
-      </div>
+      <h1 class="govuk-panel__title">Your form has been submitted <span class="govuk-visually-hidden">preview</span></h1>
     </div>
 
     {% if data['confirmationNext'] %}

--- a/app/views/form-designer/confirmation-page-preview-new-tab.html
+++ b/app/views/form-designer/confirmation-page-preview-new-tab.html
@@ -15,12 +15,13 @@
   <div class="govuk-grid-column-two-thirds">
 
     <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">Your form has been submitted <span class="govuk-visually-hidden">preview</span></h1>
+      <h1 class="govuk-panel__title">{{ data['confirmationTitle'] }} <span class="govuk-visually-hidden">preview</span></h1>
     </div>
 
-    {% if data['confirmationNext'] %}
-    <h2 class="govuk-heading-m">What happens next</h2>
 
+    <h2 class="govuk-heading-m">What happens next</h2>
+    
+    {% if data['confirmationNext'] %}
     <div class="app-prose-scope">
     {% markdown %}
       {{ data['confirmationNext'] }}

--- a/app/views/form-designer/confirmation-page-preview.html
+++ b/app/views/form-designer/confirmation-page-preview.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">Your form has been submitted</h1>
+      <h1 class="govuk-panel__title">{{ data['confirmationTitle'] }}</h1>
     </div>
 
 

--- a/app/views/form-designer/confirmation-page-preview.html
+++ b/app/views/form-designer/confirmation-page-preview.html
@@ -13,15 +13,13 @@
   <div class="govuk-grid-column-two-thirds">
 
     <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">{{data['confirmationTitle']}}</h1>
-      <div class="govuk-panel__body">
-        Your reference number is<br><strong>HDJ2123F</strong>
-      </div>
+      <h1 class="govuk-panel__title">Your form has been submitted</h1>
     </div>
 
-    {% if data['confirmationNext'] %}
+
       <h2 class="govuk-heading-m">What happens next</h2>
 
+      {% if data['confirmationNext'] %}
       <div class="app-prose-scope">
       {% markdown %}
         {{ data['confirmationNext'] }}

--- a/app/views/form-designer/edit-confirmation-page.html
+++ b/app/views/form-designer/edit-confirmation-page.html
@@ -1,15 +1,7 @@
 {% extends "layout-govuk-forms.html" %}
 
-{% set pageTitle -%}
-  {% if data['confirmationTitle'] %}
-    {{data['confirmationTitle']|safe}}
-  {% else %}
-    Confirmation
-  {% endif %}
-{%- endset %}
-
 {% block pageTitle %}
-  Edit {{pageTitle|lower}} - GOV.UK Forms
+  Edit form submitted page - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}
@@ -27,8 +19,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-l">Confirmation</span>
-      <h1 class="govuk-heading-l">{{pageTitle}}</h1>
+      <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
+      <h1 class="govuk-heading-l">Form submitted page</h1>
 
         {#
 
@@ -38,19 +30,13 @@
         #}
         {% set pagePrefix = "p" + pageId + "-" %}
 
-        {{ govukInput({
-          label: {
-            text: "Page title",
-            classes: "govuk-label--m"
-          },
-          hint: {
-            text: "Appears in the green box"
-          },
-          id: "confirmationTitle",
-          name: "confirmationTitle",
-          value: data['confirmationTitle']
-        }) }}
+        <p class="govuk-body">This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
 
+        <p class="govuk-body">Add some content to let people know what will happen next and when, so they know what to expect. For example:</p>
+
+        {{ govukInsetText({
+          text: "We'll send you an email to let you know the outcome. You'll usually get a response within 10 working days."
+        }) }}
 
         {{ govukCharacterCount({
           name: "confirmationNext",
@@ -60,9 +46,6 @@
           label: {
             text: "What happens next",
             classes: "govuk-label--m"
-          },
-          hint: {
-            text: "Tell people what will happen next and anything that they need to do"
           }
         }) }}
 
@@ -90,12 +73,8 @@
         <h2 class="govuk-heading-m">
           Page preview
         </h2>
-        <a href="../confirmation-page-preview-new-tab" class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-4 new-tab-link" target="_blank">Preview page in a new tab</a>
         <div class="preview-header">
-          <p class="preview-link govuk-body-s">
-            <!-- <a href="#" target="_blank" onclick="document.getElementById('form').submit();">Refresh</a> &nbsp;|&nbsp; -->
-            <!-- <a href="../confirmation-page-preview-new-tab" target="_blank">Open in a new tab</a> -->
-          </p>
+
         </div>
         <iframe sandbox="allow-same-origin allow-scripts" title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../confirmation-page-preview" frameborder="1" loading="lazy" id="iFrameResizer0" scrolling="no" ></iframe>
       </div>


### PR DESCRIPTION
Iterated design for adding content on 'What happens next' to the confirmation page.

[Trello reference]( https://trello.com/c/x4GJbX3l)

# User need

> As a form creator, I need to add content about what happens next to a confirmation page, so the form submitter has clear expectations.

## Changes included

In general we have simplified the page and provided more guidance.

We have decided to remove editing the title for confirmation page message and keep it general.

Removed reference number as we won't be generating it.

Edit submitted form page has iterated design, where we include form name in the H1 hint text to be consistent.

We've included additional guidance on what this page is for and how form creators could include a useful content for 'What happens next' section.

We have removed default text and hint text in the textarea for 'What happens next'. We gave an example copy in the inset text above, to encourage form creators in providing their own content for this section.

We decided that we will use a general confirmation page message in a panel: 'Your form has been submitted'.

Also removing default text for 'What happens next' section as we want to keep it empty to begin with.

## Screenshots

### After Form submitted page
![Screenshot 2022-07-21 at 14 30 16](https://user-images.githubusercontent.com/2632224/180232057-e02494f9-f763-4786-ad98-7d18067f2d9c.png)

### Before Form submitted page
![Screenshot 2022-07-21 at 15 01 21](https://user-images.githubusercontent.com/2632224/180232656-906d5c83-87d3-4d4a-81e9-47e52bac80dc.png)

### After Form submitted page preview
![Screenshot 2022-07-21 at 14 30 30](https://user-images.githubusercontent.com/2632224/180232385-2befb3a3-5c9d-498e-86ad-00a859214f9d.png)

### Before Form submitted page preview

![Screenshot 2022-07-21 at 15 01 29](https://user-images.githubusercontent.com/2632224/180232683-79320651-c93e-4141-be6f-9168d3648f61.png)

