### PR TITLE
Start at task list within the service. Some links need updated

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -232,7 +232,7 @@ router.post('/form-designer/form-create-a-form', function (req, res) {
   if(containsErrors) {
     res.render('form-designer/form-create-a-form', { errors, errorList, containsErrors })
   } else {
-    res.redirect('form-index')
+    res.redirect('create-form')
   }
 })
 

--- a/app/views/form-designer/completed-forms-email/add-confirmation-code.html
+++ b/app/views/form-designer/completed-forms-email/add-confirmation-code.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="../form-index">Back to form overview</a>
+  <a class="govuk-back-link" href="../create-form">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/completed-forms-email/confirmation-code-expired.html
+++ b/app/views/form-designer/completed-forms-email/confirmation-code-expired.html
@@ -24,7 +24,7 @@
       <p>
 
       <p class="govuk-body">
-        <a href="../form-index" class="govuk-link">Go to form overview</a>
+        <a href="../create-form" class="govuk-link">Continue creating a form</a>
       </p>
 
     </div>

--- a/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
+++ b/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
@@ -24,7 +24,7 @@
       </p>
 
       <p class="govuk-body">
-        <a href="../form-index" class="govuk-link">Go to form overview</a>
+        <a href="../create-form" class="govuk-link">Continue creating a form</a>
       </p>
 
     </div>

--- a/app/views/form-designer/completed-forms-email/email-confirmation.html
+++ b/app/views/form-designer/completed-forms-email/email-confirmation.html
@@ -20,7 +20,7 @@
       </p>
 
       <p class="govuk-body">
-        <a href="../form-index" class="govuk-link">Go to form overview</a>
+        <a href="../create-form" class="govuk-link">Continue creating a form</a>
       </p>
 
     </div>

--- a/app/views/form-designer/completed-forms-email/set-completed-forms-email.html
+++ b/app/views/form-designer/completed-forms-email/set-completed-forms-email.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="../form-index">Back to form overview</a>
+  <a class="govuk-back-link" href="../create-form">Back</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/create-form.html
+++ b/app/views/form-designer/create-form.html
@@ -1,0 +1,159 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Create a form' %}
+
+<!-- Do some checks to see how many sections are "Completed" -->
+{% set sections = 0 %}
+<!-- if form has a title sections completed =+ 1 -->
+{% if data['formTitle'] %}{% set sections = sections + 1 %}{% endif %}
+<!-- if questions added sections completed =+ 1 -->
+<!-- if summary page reviewed and confirmed sections completed =+ 1 -->
+<!-- if confirmation page reviewed and confirmed sections completed =+ 1 -->
+<!-- if processing email address added sections completed =+ 1 -->
+{% if data['formsEmail'] %}{% set sections = sections + 1 %}{% endif %}
+<!-- if processing email verified sections completed =+ 1 -->
+{% if data['confirmationCode'] %}{% set sections = sections + 1 %}{% endif %}
+
+{% block pageTitle %}
+  {{pageTitle}}: {{ data['formTitle'] }} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="form-home">Back to forms</a>
+{% endblock %}
+
+{% block content %}
+  <form id="form" class="form" action="../edit-page/{{ pageId }}" method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
+        <h1 class="govuk-heading-l">{{pageTitle}}</h1>
+
+        <!-- Keep these for now. Could still be needed/of use -->
+        {% set nextPageId = data['highestPageId'] | int + 1 %}
+        {% set totalPageNum = data['highestPageId'] | int + 2 %}
+
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form incomplete</h2>
+        <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{sections}} of 10 sections.</p>
+
+        <ol class="app-task-list">
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">1. </span> Create your form
+            </h2>
+            <ul class="app-task-list__items">
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="form-create-a-form" aria-describedby="name-of-form-status">
+                    Edit the name of your form
+                  </a>
+                </span>
+                <strong class="govuk-tag {% if not data['formTitle'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="name-of-form-status">{% if data['formTitle'] %}Completed{% else %}Not started{% endif %}</strong>
+              </li>
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="form-index" aria-describedby="add-questions-status">
+                    Add and edit your questions
+                  </a>
+                </span>
+                <strong class="govuk-tag {% if data.pages.length %}govuk-tag--blue{%else %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-questions-status">{% if data.pages.length %}In progress{% else %}Not started {% endif %}</strong>
+              </li>
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="edit-page/check-answers" aria-describedby="add-declaration-status">
+                    Review summary page and add declaration
+                  </a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="add-declaration-status">Not started</strong>
+              </li>
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="edit-page/confirmation" aria-describedby="add-what-happens-next-status">
+                    Add information about what happens next
+                  </a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="add-what-happens-next-status">Not started</strong>
+              </li>
+            </ul>
+          </li>
+
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">2. </span> Set form responses
+            </h2>
+            <ul class="app-task-list__items">
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="completed-forms-email/set-completed-forms-email" aria-describedby="processing-email-status">
+                    Set the email address completed forms will be sent to
+                  </a>
+                </span>
+                <strong class="govuk-tag {% if not data['formsEmail'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="processing-email-status">{% if data['formsEmail'] %}Completed{% else %}Not started{% endif %}</strong>
+              </li>
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  {% if data['formsEmail'] %}<a href="completed-forms-email/add-confirmation-code" aria-describedby="verified-email-status">{% endif %}
+                    Enter the email address confirmation code
+                  {% if data['formsEmail'] %}</a>{% endif %}
+                </span>
+                <strong class="govuk-tag {% if not data['confirmationCode'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="verified-email-status">{% if not data['formsEmail'] %}Cannot start yet{% elif not data['confirmationCode'] %}Not started{% else %}Completed{% endif %}</strong>
+              </li>
+            </ul>
+          </li>
+
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">3. </span> Get your form ready to go live
+            </h2>
+            <ul class="app-task-list__items">
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="#" aria-describedby="privacy-information-link-status">
+                    Provide link to your privacy information
+                  </a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="privacy-information-link-status">Not started</strong>
+              </li>
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="#" aria-describedby="accessibility-statement-link-status">
+                    Provide link to your accessibility statement
+                  </a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="accessibility-statement-link-status">Not started</strong>
+              </li>
+            </ul>
+          </li>
+
+          <li>
+            <h2 class="app-task-list__section">
+              <span class="app-task-list__section-number">4. </span> Publish your form
+            </h2>
+            <ul class="app-task-list__items">
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="#" aria-describedby="form-live-status">
+                    Make your form live
+                  </a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Not started</strong>
+              </li>
+              <li class="app-task-list__item">
+                <span class="app-task-list__task-name">
+                  <a href="form-publish" aria-describedby="publish-status">
+                    How to publish the form on GOV.UK
+                  </a>
+                </span>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="publish-status">Not started</strong>
+              </li>
+            </ul>
+          </li>
+
+        </ol>
+
+      </div>
+    </div>
+  </form>
+
+{% endblock %}

--- a/app/views/form-designer/edit-check-answers-page.html
+++ b/app/views/form-designer/edit-check-answers-page.html
@@ -17,7 +17,7 @@
   {% if prevPageId > 0 %}
     <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
   {% else %}
-    <a class="govuk-back-link" href="../form-index" target="_parent">Back</a>
+    <a class="govuk-back-link" href="../create-form" target="_parent">Back</a>
   {% endif %}
 {% endblock %}
 

--- a/app/views/form-designer/form-create-a-form.html
+++ b/app/views/form-designer/form-create-a-form.html
@@ -6,9 +6,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-{% if data['referer'] %}
-  <a class="govuk-back-link" href="{{data['referer']}}">Back</a>
-{% endif %}
+  <a class="govuk-back-link" href="create-form">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -46,4 +44,3 @@
     </div>
 
 {% endblock %}
-

--- a/app/views/form-designer/form-home.html
+++ b/app/views/form-designer/form-home.html
@@ -7,15 +7,33 @@
 {% block content %}
 
     <div class="govuk-grid-row">
+
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">GOV.UK Forms</h1>
+
         {{ govukButton({
-        text: "Create a form",
-        href: "form-create-a-form.html",
-        isStartButton: true
+          text: "Create a form",
+          href: "form-create-a-form.html",
+          classes: "govuk-!-margin-bottom-9",
+          isStartButton: true
         }) }}
       </div>
+
+      <div class="govuk-grid-column-full">
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dd class="govuk-summary-list__value">
+              {{data['formTitle']}}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="create-form">
+                Edit<span class="govuk-visually-hidden"> {{data['formTitle']}}</span>
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </div>
+
     </div>
 
 {% endblock %}
-

--- a/app/views/form-designer/form-home.html
+++ b/app/views/form-designer/form-home.html
@@ -19,6 +19,7 @@
         }) }}
       </div>
 
+      {% if data['formTitle'] %}
       <div class="govuk-grid-column-full">
         <dl class="govuk-summary-list">
           <div class="govuk-summary-list__row">
@@ -33,6 +34,7 @@
           </div>
         </dl>
       </div>
+      {% endif %}
 
     </div>
 

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -1,13 +1,13 @@
 {% extends "layout-govuk-forms.html" %}
 
+{% set pageTitle = 'Add and edit your questions' %}
+
 {% block pageTitle %}
-  Form overview: {{ data['formTitle'] }}
+  {{pageTitle}}: {{ data['formTitle'] }} - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}
-{% if data['referer'] %}
-  <a class="govuk-back-link" href="{{data['referer']}}">Back</a>
-{% endif %}
+  <a class="govuk-back-link" href="create-form">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -16,7 +16,7 @@
       <div class="govuk-grid-column-two-thirds">
 
         <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
-        <h1 class="govuk-heading-l">Form overview</h1>
+        <h1 class="govuk-heading-l">{{pageTitle}}</h1>
 
         {% set nextPageId = data['highestPageId'] | int + 1 %}
         {% set totalPageNum = data['highestPageId'] | int + 2 %}
@@ -27,22 +27,14 @@
           classes: "govuk-!-margin-bottom-3 govuk-!-margin-top-3"
         }) }}
 
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Form name</h2>
-
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-              {{ data['formTitle'] }}
-            </dt>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link govuk-link--no-visited-state" href="form-create-a-form.html">Edit<span class="govuk-visually-hidden"> form name</span></a>
-            </dd>
-          </div>
-        </dl>
-
       {% if data.pages.length %}
 
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Your questions</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Add and edit questions</h2>
+
+        <p class="govuk-body">
+          <a href="/form-designer/page-preview-new-tab/1" target="_blank">Preview the form in a new tab</a>
+        <p>
+
         <dl class="govuk-summary-list">
 
           {% for page in data.pages -%}
@@ -86,55 +78,8 @@
 
           {%- endfor %}
           </dl>
-
-          <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Standard pages</h2>
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-                <p>Check your answers</p>
-                <p class="govuk-hint">This page lists all the questions and answers so people can check them before they submit the form. You can add a declaration for people to confirm their answers.</p>
-              </dt>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-page/check-answers">
-                  Edit<span class="govuk-visually-hidden"> check your answers page</span>
-                </a>
-              </dd>
-            </div>
-
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-                <p>Form submitted</p>
-                <p class="govuk-hint">This page will be shown to confirm the form has been submitted. You can add information to tell people what will happen next.</p>
-              </dt>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-page/confirmation">
-                  Edit<span class="govuk-visually-hidden"> form submitted page</span>
-                </a>
-              </dd>
-            </div>
-          </dl>
         {% endif %}
 
-          <div class="govuk-!-margin-top-9">
-            <h2 class="govuk-heading-m">Next steps</h2>
-          {% if data.pages.length %}
-            <p class="govuk-body">
-              <a href="/form-designer/page-preview-new-tab/1" target="_blank">Preview the form in a new tab</a>
-            <p>
-          {% endif %}
-            <p class="govuk-body">
-              <a href="completed-forms-email/set-completed-forms-email">Set the email address completed forms will be sent to</a>
-            </p>
-            <p>
-            <p class="govuk-body">
-              <a href="completed-forms-email/add-confirmation-code">Enter the email address confirmation code</a>
-            </p>
-          {% if data.pages.length %}
-            <p class="govuk-body">
-              <a href="form-publish">Get your form live on GOV.UK</a>
-            </p>
-          {% endif %}
-          </div>
       </div>
 
     </div>


### PR DESCRIPTION
This gives us a starting point for trello card https://trello.com/c/qRUXjeHr/278-spike-explore-task-list-for-next-steps-in-publishing-form 

It is the first introduction of a task list pattern, with very basic functionality for now, to help us get feedback about steps in the publishing journey and being able to test the new set an email and confirm an email journeys. 

Note: still need to fix back link in the confirmation screen to go back to the task list page `create-form` instead of the overview page `form-index`

## Task list page

![Create a form with new task list view showing the different sections and steps to publishing a form. Screenshot](https://user-images.githubusercontent.com/35372982/180257717-a0e83dcd-7c69-49e7-92c3-949beed372ed.png)

