### PR TITLE
107 add number and long text answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,3 @@ Session data defaults: [/app/data/session-data-defaults.js](https://github.com/a
 Custom Sass: [/app/assets/sass/application.scss](https://github.com/alphagov/forms-prototypes/blob/main/app/assets/sass/application.scss)
 
 Form designer views: [/app/views/form-designer](https://github.com/alphagov/forms-prototypes/tree/main/app/views/form-designer)
-
-## Environment variables
-
-Set these environment variables to `true` to enable the features.
-
-| Name                                 | Purpose                                             |
-| ------------------------------------ | --------------------------------------------------- |
-| `ENABLE_MULTIPLE_CHOICE_ANSWER_TYPE` | Feature flag to enable multiple choice answer types |
-| `ENABLE_NUMBER_ANSWER_TYPE`          | Feature flag to enable numeric answer type          |

--- a/app/routes.js
+++ b/app/routes.js
@@ -55,9 +55,6 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
   var enableMultipleChoiceAnswerType =
     process.env.ENABLE_MULTIPLE_CHOICE_ANSWER_TYPE === 'true'
 
-  var enableNumberAnswerType =
-    process.env.ENABLE_NUMBER_ANSWER_TYPE === 'true'
-
   // Update the 'Highest page Id'
   req.session.data.highestPageId = req.session.data.pages.length
   var createNextPageId = parseInt(req.session.data.highestPageId) + 1
@@ -111,8 +108,7 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
       pageIndex: pageIndex,
       pageData: pageData,
       editingExistingQuestion: req.session.data.pages[pageIndex] !== undefined,
-      enableMultipleChoiceAnswerType,
-      enableNumberAnswerType
+      enableMultipleChoiceAnswerType
     })
   }
 })

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -64,9 +64,10 @@
           ]
         }) }}
 
-        {% endset -%}
+       {% endset -%}
 
-        {% set textareaHtml %}
+    {# We're not using character limit for the textarea options yet #}
+      {# {% set textareaHtml %}
         {{ govukSelect({
           id: "char-limit",
           name: namePrefix + "[char-limit]",
@@ -102,7 +103,7 @@
             }
           ]
         }) }}
-        {% endset -%}
+        {% endset -%} #}
 
         <!-- Long question text input -->
         {{ govukInput({
@@ -135,7 +136,7 @@
           name: namePrefix + "[hint-text]",
           value: pageData['hint-text']
         }) }}
-      
+
         {# <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
         <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
@@ -179,41 +180,70 @@
             {
               value: "text",
               text: "Single line of text",
-              checked: checked(namePrefix + "['type']", "text") or allEmpty
+              checked: checked(namePrefix + "['type']", "text") or allEmpty,
+              hint: {
+                text: "For a short answer of up to x characters"
+              }
+            },
+            {
+              value: "textarea",
+              text: "Multiple lines of text",
+              checked: checked(namePrefix + "['type']", "textarea"),
+              hint: {
+                text: "For longer answers of up to x characters"
+              }
             },
             {
               value: "number",
               text: "Number",
-              checked: checked(namePrefix + "['type']", "number")
-            } if enableNumberAnswerType,
+              checked: checked(namePrefix + "['type']", "number"),
+              hint: {
+                text: "Allows only numeric input"
+              }
+            },
             {
               value: "address",
               text: "Address",
-              checked: checked(namePrefix + "['type']", "address")
+              checked: checked(namePrefix + "['type']", "address"),
+              hint: {
+                text: "To collect an address with separate input fields - line 1, line 2, town or city, county and postcode"
+              }
             },
             {
               value: "date",
               text: "Date",
-              checked: checked(namePrefix + "['type']", "date")
+              checked: checked(namePrefix + "['type']", "date"),
+              hint: {
+                text: "Requires a specific day, month and year"
+              }
             },
             {
               value: "email",
               text: "Email address",
-              checked: checked(namePrefix + "['type']", "email")
+              checked: checked(namePrefix + "['type']", "email"),
+              hint: {
+                text: "The answer will be checked to make sure it's in the format of an email address"
+              }
             },
             {
               value: "national-insurance-number",
               text: "National Insurance number",
-              checked: checked(namePrefix + "['type']", "national-insurance-number")
+              checked: checked(namePrefix + "['type']", "national-insurance-number"),
+              hint: {
+                text: "The answer will be checked to make sure it's in the format of a National Insurance number"
+              }
             },
             {
               value: "phone",
               text: "Phone number",
-              checked: checked(namePrefix + "['type']", "phone")
+              checked: checked(namePrefix + "['type']", "phone"),
+              hint: {
+                text: "The answer will be checked to make sure it's in the format of a phone number"
+              }
             }
           ]
         %}
-        
+
         {% set multipleChoiceRadioItem = {
             value: "radio-checkbox",
             text: "Choosing from a list of options",
@@ -244,6 +274,7 @@
           items: radioItems
         }) }}
 
+        {# Keeping this textarea section for now in case we want to try out and test setting character limit in the future #}
         {#
             {
               value: "textarea",

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -198,7 +198,7 @@
               text: "Number",
               checked: checked(namePrefix + "['type']", "number"),
               hint: {
-                text: "Allows only numeric input"
+                text: "The answer will be checked to make sure it's in the numeric format"
               }
             },
             {

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -59,6 +59,9 @@
             hint: {text: pageData['hint-text']},
             id: pageId,
             name: pageId,
+            inputmode: "numeric",
+            pattern: "[0-9]*",
+            spellcheck: false,
             value: data[pageId | int]
           }) }}
         {% endif %}
@@ -155,22 +158,34 @@
           {% endcall %}
         {% endif %}
 
+      {# Keeping the character limit options for now in case we want to test it later #}
+
         {# Textarea with character limit #}
-        {% if (pageData['type'] == 'textarea') and (pageData['char-limit'] == 'none') %}
+        {# {% if (pageData['type'] == 'textarea') and (pageData['char-limit'] == 'none') %}
           {{ govukTextarea({
           label: label,
           hint: {text: pageData['hint-text']},
           id: pageId,
           name: pageId
         }) }}
-        {% endif %}
+        {% endif %} #}
 
         {# Textarea with no character limit #}
-        {% if (pageData['type'] == 'textarea') and not (pageData['char-limit'] == 'none') %}
+        {# {% if (pageData['type'] == 'textarea') and not (pageData['char-limit'] == 'none') %}
           {{ govukCharacterCount({
           name: pageId,
           id: pageId,
           maxlength: pageData['char-limit'],
+          label: label,
+          hint: {text: pageData['hint-text']}
+        }) }}
+        {% endif %} #}
+
+        {# Textarea no, no, there's no limits #}
+        {% if (pageData['type'] == 'textarea') %}
+        {{ govukTextarea({
+          name: pageId,
+          id: pageId,
           label: label,
           hint: {text: pageData['hint-text']}
         }) }}

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -45,7 +45,10 @@
           label: label,
           hint: {text: pageData['hint-text']},
           id: pageId,
-          name: pageId
+          name: pageId,
+          inputmode: "numeric",
+          pattern: "[0-9]*",
+          spellcheck: false
         }) }}
         {% endif %}
 
@@ -154,6 +157,16 @@
           hint: {text: pageData['hint-text']}
         }) }}
         {% endif %} #}
+
+        {# Textarea no, no, there's no limits #}
+        {% if (pageData['type'] == 'textarea') %}
+        {{ govukTextarea({
+          name: pageId,
+          id: pageId,
+          label: label,
+          hint: {text: pageData['hint-text']}
+        }) }}
+        {% endif %}
 
         {# Date field #}
         {% if pageData['type'] == 'date' %}


### PR DESCRIPTION
User need and hypothesis is in the  [Add number and long text answer
](https://github.com/alphagov/forms-prototypes/issues/107)

## Changes

Added a textarea and number as a type of answer to the Add/Edit question page
Updated the format in the both previews

As a bonus added more hint-text to all answer types, so that we can test if it's helps form creators choose the answer they expect to get

Removed setting and displaying the character count for textarea to keep it simple for now.

The answer for a number follows guidance from GOV.UK Design System, to keep it as ` type="text'` and include additional parameters for

`inputmode: "numeric",
  pattern: "[0-9]*",
 spellcheck: false`


### After - Add number and multiple lines of text in Add/Edit question page
![screencapture-localhost-3000-form-designer-edit-page-1-2022-07-25-10_21_20](https://user-images.githubusercontent.com/2632224/180743978-5d23447a-38a7-450d-acba-78f38edd3fde.png)

### Before - Add/Edit question page
![screencapture-localhost-3000-form-designer-edit-page-1-2022-07-25-10_33_13](https://user-images.githubusercontent.com/2632224/180746130-088be599-7956-4097-8296-a06d5fe67785.png)


