### PR TITLE
Set return data for testing and add links to journeys

### DIFF
--- a/app/data/returning-session-data-defaults-a11y.js
+++ b/app/data/returning-session-data-defaults-a11y.js
@@ -25,9 +25,9 @@ module.exports = {
   payments: 'no',
   pages: [
     {
-      'long-title': 'What type animal is pet?',
+      'long-title': 'What type of animal is your pet?',
       'short-title': 'Animal type',
-      'hint-text': 'For example a bird, a hat.',
+      'hint-text': 'For example a bird, cat, dog.',
       type: 'text',
       pageIndex: '0'
     },
@@ -48,26 +48,26 @@ module.exports = {
       'long-title': 'What date do you travel?',
       'short-title': 'Date',
       'hint-text': 'For example 27 3 2007',
-      type: 'address',
+      type: 'date',
       pageIndex: '3'
     },
     {
-      'long-title': 'What transport means are you using?',
+      'long-title': 'How are you travelling?',
       'short-title': 'Transport type',
       'hint-text': 'For example plane, train, car.',
-      type: 'date',
+      type: 'text',
       pageIndex: '4'
     },
     {
-      'long-title': 'How many pets do you have',
-      'short-title': 'How many pets',
-      type: 'text',
+      'long-title': 'How many pets do you have?',
+      'short-title': 'Number of pets',
+      type: 'number',
       pageIndex: '5'
     }
   ],
   status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
-  confirmationNext:'',
+  confirmationNext: 'We’ll send you an email to let you know the outcome. You’ll usually get a response within 10 working days.',
   checkAnswersTitle: 'Check your answers',
   checkAnswersDeclaration:
     'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',

--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -26,52 +26,66 @@ module.exports = {
   pages: [
     {
       intro: 'This is the intro',
-      'long-title': 'What is you name?',
-      'short-title': 'Name',
-      'hint-text': 'Enter your fuul name',
+      'long-title': 'What is your name?',
+      'short-title': 'Full name',
+      'hint-text': 'Enter your full name',
       type: 'text',
       pageIndex: '0'
     },
     {
       'long-title': 'What is your claim reference number?',
       'short-title': 'Claim reference number',
-      'hint-text': 'Begings with LN',
+      'hint-text': 'Begins with LN',
       type: 'text',
       pageIndex: '1'
     },
     {
-      'long-title': 'What is your national insurance number?',
+      'long-title': 'What is your National Insurance number?',
       'short-title': 'National Insurance number',
-      'hint-text': 'For example QQ12345C',
+      'hint-text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.',
       type: 'text',
       pageIndex: '2'
     },
     {
-      'long-title': 'What is your date of bitrh?',
-      'short-title': 'Date of Bitrh',
-      'hint-text': 'For example 27 3 2007',
-      type: 'address',
+      'long-title': 'What is the name of the company?',
+      'short-title': 'Company name',
+      type: 'text',
       pageIndex: '3'
     },
     {
-      'long-title': 'When did you submit your redundancy claim?',
-      'short-title': 'Claim submitted',
+      'long-title': 'When did your leave year start?',
+      'short-title': 'Holiday start date',
       'hint-text': 'For example 27 3 2007',
       type: 'date',
       pageIndex: '4'
     },
     {
-      'long-title': 'What is your adress?',
-      'short-title': 'Address',
-      type: 'date',
+      'long-title': 'How many holiday days were you entitled to for the full leave year?',
+      'short-title': 'Leave days entitled to',
+      'hint-text': 'Include bank holidays',
+      type: 'number',
       pageIndex: '5'
+    },
+    {
+      'long-title': 'How many holiday days did you take between the date your leave year started and the date you were made redundant?',
+      'short-title': 'Leave days taken',
+      'hint-text': 'Include any bank holidays that happened during this time',
+      type: 'number',
+      pageIndex: '6'
+    },
+    {
+      'long-title': 'How many days did you carry over from your last leave year? ',
+      'short-title': 'Days carried over from previous year',
+      'hint-text': 'If you did not carry over any days enter ‘0’',
+      type: 'number',
+      pageIndex: '7'
     }
   ],
   status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
-  confirmationNext: '',
+  confirmationNext: 'We’ll send you an email to let you know the outcome. You’ll usually get a response within 10 working days.',
   checkAnswersTitle: 'Check your answers',
   checkAnswersDeclaration:
     'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',
-  formTitle: 'Redundancy payments form: amend my personal details'
+  formTitle: 'Amendment form: redundancy claim for holiday pay'
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -237,6 +237,11 @@ router.get('/form-designer/returning', (req, res) => {
   res.redirect('/form-designer/form-list-a11y')
 })
 
+router.get('/form-designer/returning-again', (req, res) => {
+  req.session.data = returningSessionDataDefaults
+  res.redirect('/form-designer/form-list')
+})
+
 
 // Routing for publishing steps
 

--- a/app/views/form-builder-prototypes.html
+++ b/app/views/form-builder-prototypes.html
@@ -1,85 +1,92 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  Form examples
+Form examples
 {% endblock %}
 
 {% block content %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-xl">GOV.UK Forms</span>
-      <h1 class="govuk-heading-xl">
-        Form builder prototypes
-      </h1>
+    <span class="govuk-caption-xl">GOV.UK Forms</span>
+    <h1 class="govuk-heading-xl">Form builder prototypes</h1>
 
-      <p class="govuk-body-l">Prototypes exploring different aspects of form builders.<p>
+    <p class="govuk-body-l">Prototypes exploring different aspects of form builders.
+    <p>
 
-          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-          <h2 class="govuk-heading-m">
-        Page designer
-      </h2>
+    <h2 class="govuk-heading-m">Page designer</h2>
 
-          <p>
-            <b>
-              <a href="/form-designer/form-home">View the prototype</a>
-            </b>
-          </p>
+    <h3 class="govuk-heading-s">First time journey</h3>
+    <p class="govuk-body">
+      <b><a href="/form-designer/form-home">View the prototype</a></b>
+    </p>
 
-          <p>
-        A basic form page designer with the following features:
-      </p>
+    <p class="govuk-body">
+      A basic form page designer with the following features:
+    </p>
 
-          <ul class="govuk-list govuk-list--bullet">
-            <li>the interface and forms are accessible and mobile friendly</li>
-            <li>you create one page at a time, using a looping wizard</li>
-            <li>pages are designed via a form, rather than directly edited</li>
-            <li>there's a persistent mobile-sized preview pane on most pages</li>
-            <li>the preview pane is functional, so you can use it to navigate the form</li>
-          </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the interface and forms are accessible and mobile friendly</li>
+      <li>you create one page at a time, using a looping wizard</li>
+      <li>pages are designed via a form, rather than directly edited</li>
+      <li>there's a persistent mobile-sized preview pane on most pages</li>
+      <li>the preview pane is functional, so you can use it to navigate the form</li>
+    </ul>
 
-          <p>
-        Hypotheses to test:
-      </p>
+    <p class="govuk-body">
+      Hypotheses to test:
+    </p>
 
-          <ul class="govuk-list govuk-list--bullet">
-            <li>a wizard is usable by non-DDaT professionals</li>
-            <li>a wizard usefully constrains the space of possible page designs</li>
-            <li>a persitant preview pane helps users navigate the form</li>
-            <li>a persitant preview pane helps users understand which elements go where</li>
-            <li>a persitant preview pane provides reassurance about the final form</li>
-          </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>a wizard is usable by non-DDaT professionals</li>
+      <li>a wizard usefully constrains the space of possible page designs</li>
+      <li>a persitant preview pane helps users navigate the form</li>
+      <li>a persitant preview pane helps users understand which elements go where</li>
+      <li>a persitant preview pane provides reassurance about the final form</li>
+    </ul>
 
-          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-          <p>
-            <b>
-              <a href="/form-designer/returning">View return journey prototype</a>
-            </b>
-          </p>
+    <h3 class="govuk-heading-s">
+      Amendment form: redundancy claim for holiday pay return journey (Insolvency Service first form)
+    </h3>
+    <p class="govuk-body">
+      <!-- use `data/returning-session-data-defaults.js` -->
+      <b><a href="/form-designer/returning-again">View return journey prototype</a></b>
+    </p>
 
-          <ul class="govuk-list govuk-list--bullet">
-                      <li>A scenario showing a incomplete form</li>
-                    </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>A scenario showing a incomplete form</li>
+    </ul>
 
+    <h3 class="govuk-heading-s">
+      Take your pet abroad return journey (testing form)
+    </h3>
+    <p class="govuk-body">
+      <!-- use `data/returning-session-data-defaults-a11y.js` -->
+      <b><a href="/form-designer/returning">View return journey prototype</a></b>
+    </p>
 
-          <h2 class="govuk-heading-m">
-            Form publisher
-          </h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>A scenario showing a completed draft form</li>
+    </ul>
 
-          <p>
-            <b>
-              <a href="/publisher/start">View the prototype</a>
-            </b>
-          </p>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-          <p>
-            A basic form publisher with some approval features.
-          </p>
+    <h2 class="govuk-heading-m">Form publisher</h2>
 
-        </div>
-      </div>
+    <p class="govuk-body">
+      <b><a href="/publisher/start">View the prototype</a></b>
+    </p>
 
-    {% endblock %}
+    <p class="govuk-body">
+      A basic form publisher with some approval features.
+    </p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/form-designer/create-form.html
+++ b/app/views/form-designer/create-form.html
@@ -8,11 +8,15 @@
 {% if data['formTitle'] %}{% set sections = sections + 1 %}{% endif %}
 <!-- if questions added sections completed =+ 1 -->
 <!-- if summary page reviewed and confirmed sections completed =+ 1 -->
+{% if data['checkAnswersDeclaration'] %}{% set sections = sections + 1 %}{% endif %}
 <!-- if confirmation page reviewed and confirmed sections completed =+ 1 -->
+{% if data['confirmationNext'] %}{% set sections = sections + 1 %}{% endif %}
+
 <!-- if processing email address added sections completed =+ 1 -->
 {% if data['formsEmail'] %}{% set sections = sections + 1 %}{% endif %}
 <!-- if processing email verified sections completed =+ 1 -->
 {% if data['confirmationCode'] and (data['confirmationCode'] !== '000000') %}{% set sections = sections + 1 %}{% endif %}
+
 
 {% block pageTitle %}
   {{pageTitle}}: {{ data['formTitle'] }} - GOV.UK Forms
@@ -65,7 +69,7 @@
                     Review summary page and add declaration
                   </a>
                 </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="add-declaration-status">Not started</strong>
+                <strong class="govuk-tag {% if not data['checkAnswersDeclaration'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-declaration-status">{% if not data['checkAnswersDeclaration'] %}Not started{% else %}Completed{% endif %}</strong>
               </li>
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
@@ -73,7 +77,7 @@
                     Add information about what happens next
                   </a>
                 </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="add-what-happens-next-status">Not started</strong>
+                <strong class="govuk-tag {% if not data['confirmationNext'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-what-happens-next-status">{% if not data['confirmationNext'] %}Not started{% else %}Completed{% endif %}</strong>
               </li>
             </ul>
           </li>

--- a/app/views/form-designer/form-list-a11y.html
+++ b/app/views/form-designer/form-list-a11y.html
@@ -10,7 +10,8 @@
   {{ govukButton({
     text: "Create a form",
     classes: "govuk-button--primary",
-    href: "unpublish-confirm"
+    href: "create-form",
+    isStartButton: true
   }) }}
 
   <h2 class="govuk-heading-m">Your forms</h2>

--- a/app/views/form-designer/form-list-a11y.html
+++ b/app/views/form-designer/form-list-a11y.html
@@ -1,47 +1,29 @@
 {% extends "layout-govuk-forms.html" %}
 
 {% block pageTitle %}
-  Form list - GOV.UK Forms
+  Your forms - GOV.UK Forms
 {% endblock %}
 
 {% block content %}
-<h1 class="govuk-heading-l">GOV.UK Forms</h1>
+  <h1 class="govuk-heading-l">GOV.UK Forms</h1>
 
-{{ govukButton({
+  {{ govukButton({
     text: "Create a form",
     classes: "govuk-button--primary",
     href: "unpublish-confirm"
-}) }}
+  }) }}
 
-<h2 class="govuk-heading-m">Your forms</h2>
-<dl class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-    <p class="govuk-body">{{ data.formTitle }}</p>
-      </dt>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/form-index">Edit <span class="govuk-visually-hidden">{{ data.formTitle }}</span></a>
-    </dd>
-  </div>
+  <h2 class="govuk-heading-m">Your forms</h2>
+  <dl class="govuk-summary-list">
 
-  <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-      <p class="govuk-body">Apply for a juggling licence</p>
-        </dt>
+        <p class="govuk-body">{{ data.formTitle }}</p>
+      </dt>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="#not-found">Edit <span class="govuk-visually-hidden">Apply for a juggling licence</span></a>
+        <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/create-form">Edit <span class="govuk-visually-hidden">{{ data.formTitle }}</span></a>
       </dd>
     </div>
 
-    <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-        <p class="govuk-body">Apply to use acronym</p>
-          </dt>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="#not-found">Edit <span class="govuk-visually-hidden">Apply to use acronym</span></a>
-        </dd>
-      </div>
-
-</dl>
-
+  </dl>
 {% endblock %}

--- a/app/views/form-designer/form-list.html
+++ b/app/views/form-designer/form-list.html
@@ -1,48 +1,29 @@
 {% extends "layout-govuk-forms.html" %}
 
 {% block pageTitle %}
-  GOV.UK Forms
+  Your forms - GOV.UK Forms
 {% endblock %}
 
 {% block content %}
-<h1 class="govuk-heading-l">GOV.UK Forms</h1>
+  <h1 class="govuk-heading-l">GOV.UK Forms</h1>
 
-{{ govukButton({
-    text: "Create a form",
-    classes: "govuk-button--primary",
-    href: "unpublish-confirm"
-}) }}
+  {{ govukButton({
+      text: "Create a form",
+      classes: "govuk-button--primary",
+      href: "unpublish-confirm"
+  }) }}
 
-<h2 class="govuk-heading-m">Your forms</h2>
-<dl class="govuk-summary-list">
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-    <p class="govuk-body">{{ data.formTitle }}</p>
-      </dt>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/form-index">Edit <span class="govuk-visually-hidden">{{ data.formTitle }}</span></a>
-    </dd>
-  </div>
+  <h2 class="govuk-heading-m">Your forms</h2>
+  <dl class="govuk-summary-list">
 
-  <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-      <p class="govuk-body">Redundancy payments form: amend my claim for holiday taken but not paid</p>
-        </dt>
+        <p class="govuk-body">{{ data.formTitle }}</p>
+      </dt>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="#not-found">Edit <span class="govuk-visually-hidden">Redundancy payments form: amend my claim for holiday taken but not paid</span></a>
+        <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/create-form">Edit <span class="govuk-visually-hidden">{{ data.formTitle }}</span></a>
       </dd>
     </div>
 
-    <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-!-width-full govuk-!-font-weight-regular">
-        <p class="govuk-body">Redundancy payments form: amend my claim for unpaid wages</p>
-          </dt>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="#not-found">Edit <span class="govuk-visually-hidden">Redundancy payments form: amend my claim for unpaid wages</span></a>
-        </dd>
-      </div>
-
-</dl>
-
+  </dl>
 {% endblock %}
-

--- a/app/views/form-designer/form-list.html
+++ b/app/views/form-designer/form-list.html
@@ -10,7 +10,8 @@
   {{ govukButton({
       text: "Create a form",
       classes: "govuk-button--primary",
-      href: "unpublish-confirm"
+      href: "create-form",
+      isStartButton: true
   }) }}
 
   <h2 class="govuk-heading-m">Your forms</h2>


### PR DESCRIPTION
Things that I've changed:

- update Insolvency Service form to the new first form - Amendment form: redundancy claim for holiday pay
- update the "Take your pet abroad" form
- added a link to both forms from the ["Form builder prototypes" page](https://forms-prototypes.london.cloudapps.digital/form-builder-prototypes)
- fixed intentional typos across both forms
- added "Completed" status checks to the Task list page for Summary (CYA)/Declaration screen
- added "Completed" status checks to the Task list page for Confirmation screen
- removed extra (non working) links from the GOV.UK Forms - Your forms page
- updated edit link on the GOV.UK Forms - Your forms page to go to the new Task list page instead of directly into the Form overview page

### New links to return journeys
<img width="653" alt="New prototype links for return journey testing. Screenshot" src="https://user-images.githubusercontent.com/35372982/181029360-1b56c336-9bb0-4ff6-92da-740c1e41a5db.png">

