### PR TITLE
112 design and content for the check your answers page and declaration

### DIFF
--- a/app/data/returning-session-data-defaults-a11y.js
+++ b/app/data/returning-session-data-defaults-a11y.js
@@ -68,7 +68,7 @@ module.exports = {
   status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
   confirmationNext: 'We’ll send you an email to let you know the outcome. You’ll usually get a response within 10 working days.',
-  checkAnswersTitle: 'Check your answers',
+  checkAnswersTitle: 'Check your answers before submitting your form',
   checkAnswersDeclaration:
     'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',
   formTitle: 'Take your pet abroad'

--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -84,7 +84,7 @@ module.exports = {
   status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
   confirmationNext: 'We’ll send you an email to let you know the outcome. You’ll usually get a response within 10 working days.',
-  checkAnswersTitle: 'Check your answers',
+  checkAnswersTitle: 'Check your answers before submitting your form',
   checkAnswersDeclaration:
     'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.',
   formTitle: 'Amendment form: redundancy claim for holiday pay'

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -29,5 +29,5 @@ module.exports = {
   pages: [],
   status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
-  checkAnswersTitle: 'Check your answers'
+  checkAnswersTitle: 'Check your answers before submitting your form'
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -29,7 +29,5 @@ module.exports = {
   pages: [],
   status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
-  confirmationNext: '',
-  checkAnswersTitle: 'Check your answers',
-  checkAnswersDeclaration: 'By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct.'
+  checkAnswersTitle: 'Check your answers'
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -60,23 +60,60 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
   var createNextPageId = parseInt(req.session.data.highestPageId) + 1
 
   // If user is creating a page from the check your answers page...
-  if (pageId == 'check-answers' && action == 'createNextPage') {
-    res.redirect('/form-designer/edit-page/' + createNextPageId)
+  if (pageId == 'check-answers') {
+    const errors = {};
+    const { checkAnswersDeclaration } = req.session.data
 
-    // If user is updating the check your answers page...
-  } else if (
-    pageId == 'check-answers' &&
-    (action == 'update' || action == '')
-  ) {
-    res.render('form-designer/edit-check-answers-page')
+    // If the formsEmail is blank, create an error to be displayed to the user
+    if (!checkAnswersDeclaration?.length) {
+      errors.checkAnswersDeclaration = {
+        text: 'Enter a declaration',
+        href: "#checkAnswersDeclaration"
+      }
+    }
 
-    // If user is creating a page from the confirmation page...
-  } else if (pageId == 'confirmation' && action == 'createNextPage') {
-    res.redirect('/form-designer/edit-page/' + createNextPageId)
+    // Convert the errors into a list, so we can use it in the template
+    const errorList = Object.values(errors)
+    // If there are no errors, redirect the user to the next page
+    // otherwise, show the page again with the errors set
+    const containsErrors = errorList.length > 0
+    if(containsErrors && action !== '') {
+      res.render('form-designer/edit-check-answers-page', { errors, errorList, containsErrors })
+    } else if(action == 'continue') {
+      // Reset the state so they can be reused
+      req.session.data.action = undefined
+      res.redirect('/form-designer/create-form')
+    } else {
+      res.render('form-designer/edit-check-answers-page')
+    }
 
     // If user is updating the confirmation page...
-  } else if (pageId == 'confirmation' && (action == 'update' || action == '')) {
-    res.render('form-designer/edit-confirmation-page')
+  } else if (pageId == 'confirmation') {
+    const errors = {};
+    const { confirmationNext } = req.session.data
+
+    // If the formsEmail is blank, create an error to be displayed to the user
+    if (!confirmationNext?.length) {
+      errors.confirmationNext = {
+        text: 'Enter what happens next',
+        href: "#confirmationNext"
+      }
+    }
+
+    // Convert the errors into a list, so we can use it in the template
+    const errorList = Object.values(errors)
+    // If there are no errors, redirect the user to the next page
+    // otherwise, show the page again with the errors set
+    const containsErrors = errorList.length > 0
+    if(containsErrors && action !== '') {
+      res.render('form-designer/edit-confirmation-page', { errors, errorList, containsErrors })
+    } else if(action == 'continue') {
+      // Reset the state so they can be reused
+      req.session.data.action = undefined
+      res.redirect('/form-designer/create-form')
+    } else {
+      res.render('form-designer/edit-confirmation-page')
+    }
 
     // If user is updating the start page...
   } else if (pageId == 0 && (action == 'update' || action == '')) {

--- a/app/views/form-designer/edit-check-answers-page.html
+++ b/app/views/form-designer/edit-check-answers-page.html
@@ -1,86 +1,83 @@
 {% extends "layout-govuk-forms.html" %}
 
-{% set pageTitle -%}
-  {% if data['checkAnswersTitle'] %}
-    {{data['checkAnswersTitle']|safe}}
-  {% else %}
-    Check your answers
-  {% endif %}
-{%- endset %}
+{% set pageTitle = 'Form summary page' %}
 
 {% block pageTitle %}
-  Edit {{pageTitle|lower}} - GOV.UK Forms
+  {{ "Error: " if containsErrors }}Edit {{pageTitle|lower}} - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}
   {% set prevPageId = pageId | int - 1 %}
   {% if prevPageId > 0 %}
-    <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
+    <a class="govuk-back-link" href="{{prevPageId}}">
+      Back
+    </a>
   {% else %}
-    <a class="govuk-back-link" href="../create-form" target="_parent">Back</a>
+    <a class="govuk-back-link" href="../create-form" target="_parent">
+      Back to create a form
+    </a>
   {% endif %}
 {% endblock %}
 
 {% block content %}
 
+{% if containsErrors %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList
+  }) }}
+{% endif %}
+
 <form id="form" class="form" action="check-answers" method="post">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <span class="govuk-caption-l">Check your answers</span>
+      <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
       <h1 class="govuk-heading-l">{{pageTitle}}</h1>
 
-        {#
+      {#
 
-        Every field id is prefixed with a unique page id.
-        So we can have separate configurations for every page.
+      Every field id is prefixed with a unique page id.
+      So we can have separate configurations for every page.
 
-        #}
-        {% set pagePrefix = "p" + pageId + "-" %}
+      #}
+      {% set pagePrefix = "p" + pageId + "-" %}
 
-        {{ govukInput({
-          label: {
-            text: "Page title",
-            classes: "govuk-label--m"
-          },
-          hint: {
-            text: "Appears at the top of the page"
-          },
-          id: "checkAnswersTitle",
-          name: "checkAnswersTitle",
-          value: data['checkAnswersTitle']
+      <p class="govuk-body">This page lists all the questions and answers so people can check them before they submit the form.</p>
+
+      <p class="govuk-body">You can add a declaration for people to confirm their answers. For example:</p>
+
+      {{ govukInsetText({
+        text: "By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct."
+      }) }}
+
+      {{ govukCharacterCount({
+        name: "checkAnswersDeclaration",
+        id: "checkAnswersDeclaration",
+        maxlength: 2000,
+        value: data['checkAnswersDeclaration'],
+        label: {
+          text: "Declaration",
+          classes: "govuk-label--m"
+        },
+        errorMessage: { text: errors['checkAnswersDeclaration'].text } if errors['checkAnswersDeclaration'].text
+      }) }}
+
+      <input type="hidden" id="currentPageId" name="currentPageId" value="{{pageId}}">
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Save and continue",
+          name: "action",
+          value: "continue"
         }) }}
-
-
-        {{ govukCharacterCount({
-          name: "checkAnswersDeclaration",
-          id: "checkAnswersDeclaration",
-          maxlength: 2000,
-          value: data['checkAnswersDeclaration'],
-          label: {
-            text: "Declaration",
-            classes: "govuk-label--m"
-          },
-          hint: {
-            text: "The declaration that people make when they submit the form"
-          }
+        {{ govukButton({
+          text:  "Save and preview",
+          name: "action",
+          value: "update",
+          classes: "govuk-button--secondary"
         }) }}
-
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-        <input type="hidden" id="currentPageId" name="currentPageId" value="{{pageId}}">
-
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Save changes",
-            name: "action",
-            value: "update"
-          }) }}
-        </div>
-
-        <p class="govuk-body">
-          <a class="govuk-link govuk-link--no-visited-state" href="../form-index">Go to form overview</a>
-        </p>
+      </div>
 
     </div>
 
@@ -89,7 +86,6 @@
         <h2 class="govuk-heading-m">
           Page preview
         </h2>
-        <a href="../check-answers-page-preview-new-tab" class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-4 new-tab-link" target="_blank">Preview page in a new tab</a>
         <div class="preview-header">
           <p class="preview-link govuk-body-s">
             <!-- <a href="#" target="_blank" onclick="document.getElementById('form').submit();">Refresh</a> &nbsp;|&nbsp; -->

--- a/app/views/form-designer/edit-confirmation-page.html
+++ b/app/views/form-designer/edit-confirmation-page.html
@@ -1,44 +1,57 @@
 {% extends "layout-govuk-forms.html" %}
 
+{% set pageTitle = 'Form submitted page' %}
+
 {% block pageTitle %}
-  Edit form submitted page - GOV.UK Forms
+  {{ "Error: " if containsErrors }}Edit {{pageTitle|lower}} - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}
   {% set prevPageId = pageId | int - 1 %}
   {% if prevPageId > 0 %}
-    <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
+    <a class="govuk-back-link" href="{{prevPageId}}">
+      Back
+    </a>
   {% else %}
-    <a class="govuk-back-link" href="../create-form" target="_parent">Back</a>
+    <a class="govuk-back-link" href="../create-form" target="_parent">
+      Back to create a form
+    </a>
   {% endif %}
 {% endblock %}
 
 {% block content %}
+
+{% if containsErrors %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList
+  }) }}
+{% endif %}
 
 <form id="form" class="form" action="confirmation" method="post">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
       <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
-      <h1 class="govuk-heading-l">Form submitted page</h1>
+      <h1 class="govuk-heading-l">{{pageTitle}}</h1>
 
-        {#
+      {#
 
         Every field id is prefixed with a unique page id.
         So we can have separate configurations for every page.
 
-        #}
-        {% set pagePrefix = "p" + pageId + "-" %}
+      #}
+      {% set pagePrefix = "p" + pageId + "-" %}
 
-        <p class="govuk-body">This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
+      <p class="govuk-body">This page will be shown after someone has completed and submitted the form to let them know that the form has been submitted successfully.</p>
 
-        <p class="govuk-body">Add some content to let people know what will happen next and when, so they know what to expect. For example:</p>
+      <p class="govuk-body">Add some content to let people know what will happen next and when, so they know what to expect. For example:</p>
 
-        {{ govukInsetText({
+      {{ govukInsetText({
           text: "We'll send you an email to let you know the outcome. You'll usually get a response within 10 working days."
         }) }}
 
-        {{ govukCharacterCount({
+      {{ govukCharacterCount({
           name: "confirmationNext",
           id: "confirmationNext",
           maxlength: 2000,
@@ -46,25 +59,25 @@
           label: {
             text: "What happens next",
             classes: "govuk-label--m"
-          }
+          },
+          errorMessage: { text: errors['confirmationNext'].text } if errors['confirmationNext'].text
         }) }}
 
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <input type="hidden" id="currentPageId" name="currentPageId" value="{{pageId}}">
 
-        <input type="hidden" id="currentPageId" name="currentPageId" value="{{pageId}}">
-
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Save changes",
-            name: "action",
-            value: "update"
-          }) }}
-        </div>
-
-        <p class="govuk-body">
-          <a class="govuk-link govuk-link--no-visited-state" href="../form-index">Go to form overview</a>
-        </p>
-
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Save and continue",
+          name: "action",
+          value: "continue"
+        }) }}
+        {{ govukButton({
+          text:  "Save and preview",
+          name: "action",
+          value: "update",
+          classes: "govuk-button--secondary"
+        }) }}
+      </div>
 
     </div>
 
@@ -76,7 +89,8 @@
         <div class="preview-header">
 
         </div>
-        <iframe sandbox="allow-same-origin allow-scripts" title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../confirmation-page-preview" frameborder="1" loading="lazy" id="iFrameResizer0" scrolling="no" ></iframe>
+        <iframe sandbox="allow-same-origin allow-scripts" title="Page preview" data-module="app-example-frame" class="preview-pane app-example__frame app-example__frame--resizable" src="../confirmation-page-preview" frameborder="1" loading="lazy"
+          id="iFrameResizer0" scrolling="no"></iframe>
       </div>
     </div>
 

--- a/app/views/form-designer/form-create-a-form.html
+++ b/app/views/form-designer/form-create-a-form.html
@@ -2,7 +2,7 @@
 
 
 {% block pageTitle %}
-  {{ "Error:" if containsErrors }} What is the name of your form? - GOV.UK Forms
+  {{ "Error: " if containsErrors }}What is the name of your form? - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
## Changes made

### Check your answers page

- updated caption to pull through form name - no longer shows page type name for example, "Check your answers"
- changed H1 on the edit page: "Form summary page"
- made H1 on the edit page static - the user is no longer able to change this
- added new explainer content to page to help users understand what the page is for and does
- added new inset text to give a usable example to form creator so they have a better idea of what could be included here
- made the "Declaration" text area mandatory giving an error if empty: "Enter a declaration" @hannahkc to review
- removed the line rule from the screen as this doesn't align with other pages in the service (should be used more sparingly)
- updated green button action to take user back to "Create a form" task list page
- added new secondary "Save and preview" grey button which will save changes and reload page with changes made in the in page preview window
- removed the "Go to form overview" link as no longer needed
- changed H1 on end user facing page: "Check your answers before submitting your form"

#### Screenshot of check your answers (summary) page
![New form summary page without title input box and new declaration text area. Also shows new secondary grey button with save and preview. Screenshot](https://user-images.githubusercontent.com/35372982/181546809-cf5aa7be-5140-4da0-ad20-a2500acbfd37.png)


### Confirmation page

- made the "What happens next" text area mandatory giving an error if empty: "Enter what happens next" @hannahkc to review
- removed the line rule from the screen as this doesn't align with other pages in the service (should be used more sparingly)
- updated green button action to take user back to "Create a form" task list page
- added new secondary "Save and preview" grey button which will save changes and reload page with changes made in the in page preview window
- removed the "Go to form overview" link as no longer needed

#### Screenshot of form submitted (confirmation) page
![New form submitted page with new secondary grey button with save and preview. Screenshot](https://user-images.githubusercontent.com/35372982/181549929-70980d87-908f-456c-9179-86b8262d80bd.png)

