### PR TITLE
New return journey for option 1 added

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -191,3 +191,44 @@ $govuk-assets-path: "/govuk/assets/";
   background-position: 50% 0;
   background-size: contain;
 }
+
+
+// Copy URL styling
+// Tooltip
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 140px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  bottom: 150%;
+  left: 50%;
+  margin-left: -75px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}

--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -81,7 +81,7 @@ module.exports = {
       pageIndex: '7'
     }
   ],
-  status: 'Draft',
+  status: 'Live',
   confirmationTitle: 'Your form has been submitted',
   checkAnswersTitle: 'Check your answers before submitting your form',
   formTitle: 'Amendment form: redundancy claim for holiday pay'

--- a/app/routes.js
+++ b/app/routes.js
@@ -373,4 +373,34 @@ router.post('/form-designer/completed-forms-email/add-confirmation-code', functi
   }
 })
 
+
+// Renders the page which asks to confirm editing live questions/form, handling validation errors
+router.post('/form-designer/are-you-sure-you-want-to-edit-live-questions', function (req, res) {
+  const errors = {};
+  const { editLiveQuestions } = req.session.data
+
+  // If the changeFormsEmail has selection, create an error to be displayed to the user
+  if (!editLiveQuestions || !editLiveQuestions.length) {
+    errors['editLiveQuestions'] = {
+      text: 'Select no if you do not want to edit your questions',
+      href: "#editLiveQuestions"
+    }
+  }
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  if(containsErrors) {
+    res.render('form-designer/are-you-sure-you-want-to-edit-live-questions', { errors, errorList, containsErrors })
+  } else {
+    if(editLiveQuestions === 'yes') {
+      res.redirect('form-index')
+    } else {
+      res.redirect('create-form')
+    }
+  }
+})
+
 module.exports = router

--- a/app/views/form-designer/are-you-sure-you-want-to-edit-live-questions.html
+++ b/app/views/form-designer/are-you-sure-you-want-to-edit-live-questions.html
@@ -1,0 +1,67 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Add and edit questions' %}
+{% set pageQuestion = 'Are you sure you want to edit the questions?' %}
+
+{% block pageTitle %}
+  {{pageTitle}} - {{pageQuestion}} - GOV.UK Forms
+{% endblock %}
+
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="{{data['referer']}}">Back your form</a>
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {{pageTitle}}
+    </h1>
+
+    <p class="govuk-body">
+      Your form is live.
+    </p>
+
+    <p class="govuk-body">
+      Any changes you make to the questions in your form will be updated in the live form immediately.
+    </p>
+
+    <p class="govuk-body">
+      This could have an impact on people who are filling in the form at the same time. They may lose any answers they have already provided and may need to start again.
+    </p>
+
+    <form method="post">
+      {{ govukRadios({
+        idPrefix: "editLiveQuestions",
+        name: "editLiveQuestions",
+        fieldset: {
+          legend: {
+            text: "Are you sure you want to edit the questions?",
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+
+
+{% endblock %}

--- a/app/views/form-designer/create-form.html
+++ b/app/views/form-designer/create-form.html
@@ -1,6 +1,9 @@
 {% extends "layout-govuk-forms.html" %}
 
-{% set pageTitle = 'Create a form' %}
+
+{% set pageTitle -%}
+{% if data['status'] === 'Live' %}Your form{% else %}Create a form{% endif %}
+{%- endset %}
 
 <!-- Do some checks to see how many sections are "Completed" -->
 {% set sections = 0 %}
@@ -32,21 +35,42 @@
       <div class="govuk-grid-column-two-thirds">
 
         <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
-        <h1 class="govuk-heading-l">{{pageTitle}}</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{pageTitle}}</h1>
+        {% if data['status'] %}
+        {{govukTag({
+          text: data['status'],
+          classes: "govuk-!-margin-bottom-7 govuk-tag--purple" if data['status'] === 'Draft' else "govuk-!-margin-bottom-7 govuk-tag--turquoise"
+        })}}
+        {% endif %}
 
         <!-- Keep these for now. Could still be needed/of use -->
         {% set nextPageId = data['highestPageId'] | int + 1 %}
         {% set totalPageNum = data['highestPageId'] | int + 2 %}
 
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form incomplete</h2>
-        <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{sections}} of 10 sections.</p>
+        {% if data['status'] === 'Live' %}
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form is live</h2>
+          <p class="govuk-body">The URL for your form is:</p>
+          <p class="govuk-body">
+            <input class="govuk-input" type="text" id="formURL" value="forms.service.gov.uk/example-url" style="background-color:#f3f2f1;border-color:#b1b4b6;">
+          </p>
+          <div class="tooltip">
+            <span class="tooltiptext govuk-body" id="copyURLTooltip">Copy to clipboard</span>
+            <button class="govuk-button govuk-button--secondary" type="button" onclick="copyURL()">
+              Copy URL
+            </button>
+          </div>
+        {% else %}
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form incomplete</h2>
+          <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{sections}} of 8 sections.</p>
+        {% endif %}
 
         <ol class="app-task-list">
           <li>
             <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">1. </span> Create your form
+              <span class="app-task-list__section-number">1. </span> {% if data['status'] === 'Live' %}Edit your form{% else %}Create your form{% endif %}
             </h2>
             <ul class="app-task-list__items">
+              {% if data['status'] === 'Draft' %}
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
                   <a href="form-create-a-form" aria-describedby="name-of-form-status">
@@ -55,13 +79,16 @@
                 </span>
                 <strong class="govuk-tag {% if not data['formTitle'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="name-of-form-status">{% if data['formTitle'] %}Completed{% else %}Not started{% endif %}</strong>
               </li>
+              {% endif %}
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
-                  <a href="form-index" aria-describedby="add-questions-status">
+                  <a href="{% if data['status'] === 'Live' %}are-you-sure-you-want-to-edit-live-questions{% else %}form-index{% endif %}" aria-describedby="add-questions-status">
                     Add and edit your questions
                   </a>
                 </span>
+                {% if data['status'] === 'Draft' %}
                 <strong class="govuk-tag {% if data.pages.length %}govuk-tag--blue{%else %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-questions-status">{% if data.pages.length %}In progress{% else %}Not started {% endif %}</strong>
+                {% endif %}
               </li>
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
@@ -69,7 +96,8 @@
                     Review summary page and add declaration
                   </a>
                 </span>
-                <strong class="govuk-tag {% if not data['checkAnswersDeclaration'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-declaration-status">{% if not data['checkAnswersDeclaration'] %}Not started{% else %}Completed{% endif %}</strong>
+                {% if data['status'] === 'Draft' %}
+                <strong class="govuk-tag {% if not data['checkAnswersDeclaration'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-declaration-status">{% if not data['checkAnswersDeclaration'] %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
               </li>
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
@@ -77,7 +105,8 @@
                     Add information about what happens next
                   </a>
                 </span>
-                <strong class="govuk-tag {% if not data['confirmationNext'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-what-happens-next-status">{% if not data['confirmationNext'] %}Not started{% else %}Completed{% endif %}</strong>
+                {% if data['status'] === 'Draft' %}
+                <strong class="govuk-tag {% if not data['confirmationNext'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-what-happens-next-status">{% if not data['confirmationNext'] %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
               </li>
             </ul>
           </li>
@@ -93,15 +122,18 @@
                     Set the email address completed forms will be sent to
                   </a>
                 </span>
+                {% if data['status'] === 'Draft' %}
                 <strong class="govuk-tag {% if not data['formsEmail'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="processing-email-status">{% if data['formsEmail'] %}Completed{% else %}Not started{% endif %}</strong>
+                {% endif %}
               </li>
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
-                  {% if data['formsEmail'] %}<a href="completed-forms-email/add-confirmation-code" aria-describedby="verified-email-status">{% endif %}
+                  {% if data['formsEmail'] or data['status'] === 'Live' %}<a href="completed-forms-email/add-confirmation-code" aria-describedby="verified-email-status">{% endif %}
                     Enter the email address confirmation code
-                  {% if data['formsEmail'] %}</a>{% endif %}
+                  {% if data['formsEmail'] or data['status'] === 'Live' %}</a>{% endif %}
                 </span>
-                <strong class="govuk-tag {% if not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}govuk-tag--grey{% endif %} app-task-list__tag" id="verified-email-status">{% if not data['formsEmail'] %}Cannot start yet{% elif not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}Not started{% else %}Completed{% endif %}</strong>
+                {% if data['status'] === 'Draft' %}
+                <strong class="govuk-tag {% if not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}govuk-tag--grey{% endif %} app-task-list__tag" id="verified-email-status">{% if not data['formsEmail'] %}Cannot start yet{% elif not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
               </li>
             </ul>
           </li>
@@ -114,50 +146,79 @@
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
                   <a href="#" aria-describedby="privacy-information-link-status">
-                    Provide link to your privacy information
+                    Provide a link to your privacy information
                   </a>
                 </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="privacy-information-link-status">Not started</strong>
-              </li>
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="#" aria-describedby="accessibility-statement-link-status">
-                    Provide link to your accessibility statement
-                  </a>
-                </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="accessibility-statement-link-status">Not started</strong>
+                {% if data['status'] === 'Draft' %}
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="privacy-information-link-status">Not started</strong>{% endif %}
               </li>
             </ul>
           </li>
 
+          {% if data['status'] === 'Draft' %}
           <li>
             <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">4. </span> Publish your form
+              <span class="app-task-list__section-number">4. </span> Make your form live
             </h2>
             <ul class="app-task-list__items">
               <li class="app-task-list__item">
                 <span class="app-task-list__task-name">
-                  <a href="#" aria-describedby="form-live-status">
+                  {% if sections >= 7 -%}<a href="#" aria-describedby="form-live-status">{%- endif %}
                     Make your form live
-                  </a>
+                  {% if sections >= 7 -%}</a>{%- endif %}
                 </span>
+                {% if data['status'] === 'Live' -%}
+                <strong class="govuk-tag app-task-list__tag" id="form-live-status">Completed</strong>
+                {%- elif sections >= 7 -%}
                 <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Not started</strong>
-              </li>
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="form-publish" aria-describedby="publish-status">
-                    How to publish the form on GOV.UK
-                  </a>
-                </span>
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="publish-status">Not started</strong>
+                {%- else -%}
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Cannot start yet</strong>
+                {%- endif %}
               </li>
             </ul>
-          </li>
+          </li>{% endif %}
 
         </ol>
+
+        {% if data['status'] === 'Live' %}
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Publish your form on GOV.UK</h2>
+        <p class="govuk-body">
+          Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+        </p>
+        {% endif %}
+
+        {% if data['formTitle'] %}
+        <p class="govuk-body govuk-!-margin-top-9">
+          {{ govukButton({
+            text: "Delete form",
+            classes: "govuk-button--warning"
+          }) }}
+        </p>
+        {% endif %}
 
       </div>
     </div>
   </form>
 
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript">
+  function copyURL() {
+    console.log('Hello')
+    /* Get the text field */
+    var copyText = document.getElementById("formURL");
+
+    /* Select the text field */
+    copyText.select();
+    copyText.setSelectionRange(0, 99999); /* For mobile devices */
+
+     /* Copy the text inside the text field */
+    navigator.clipboard.writeText(copyText.value);
+
+    /* Alert the copied text */
+    var tooltip = document.getElementById("copyURLTooltip");
+    tooltip.innerHTML = "Copied to clipboard";
+  }
+</script>
 {% endblock %}

--- a/app/views/form-designer/form-index.html
+++ b/app/views/form-designer/form-index.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="create-form">Back</a>
+  <a class="govuk-back-link" href="create-form">Back to {% if data['status'] === 'Live' %}your form{% else %}create a form{% endif %}</a>
 {% endblock %}
 
 {% block content %}
@@ -15,8 +15,34 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
+        {% if data['status'] === 'Live' %}
+        <div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              Important
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <h3 class="govuk-notification-banner__heading">
+              Any changes you make to a live form will be updated in the form immediately.
+            </h3>
+            <p class="govuk-body">
+              This could have an impact on people who are filling in the form at the same time. They may lose any answers they have already provided and may need to start again. 
+            </p>
+          </div>
+        </div>
+        {% endif %}
+
         <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
-        <h1 class="govuk-heading-l">{{pageTitle}}</h1>
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{pageTitle}}</h1>
+        {% if data['status'] %}
+        <div>
+          {{govukTag({
+            text: data['status'],
+            classes: "govuk-!-margin-bottom-7 govuk-tag--purple" if data['status'] === 'Draft' else "govuk-!-margin-bottom-7 govuk-tag--turquoise"
+          })}}
+        </div>
+        {% endif %}
 
         {% set nextPageId = data['highestPageId'] | int + 1 %}
         {% set totalPageNum = data['highestPageId'] | int + 2 %}
@@ -24,14 +50,14 @@
         {{ govukButton({
           text: "Add a question",
           href: "choose-page-type/" + nextPageId,
-          classes: "govuk-!-margin-bottom-3 govuk-!-margin-top-3"
+          classes: "govuk-!-margin-bottom-7"
         }) }}
 
       {% if data.pages.length %}
 
-        <h2 class="govuk-heading-m govuk-!-margin-top-7 govuk-!-margin-bottom-0">Add and edit questions</h2>
+        <h2 class="govuk-heading-m">Add and edit questions</h2>
 
-        <p class="govuk-body">
+        <p class="govuk-body govuk-!-margin-bottom-9">
           <a href="/form-designer/page-preview-new-tab/1" target="_blank">Preview the form in a new tab</a>
         <p>
 


### PR DESCRIPTION
Added return journey for option 1 agreed with developers

See [MURAL screens](https://app.mural.co/t/gaap0347/m/gaap0347/1652697480711/fa60d6e36c472088d3c49ea4a7e7fc5b1d8186d4?wid=0-1659519691366)

I have included the interrupt page, but this can be a nice to have when we put into development if there is time.

May need to revisit some of the linking once we update live links and privacy journeys