### PR TITLE
Add make form live journey

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -403,4 +403,32 @@ router.post('/form-designer/are-you-sure-you-want-to-edit-live-questions', funct
   }
 })
 
+router.post('/form-designer/make-your-form-live', function (req, res) {
+  const errors = {};
+  const { makeFormLive } = req.session.data
+
+  // If the user haven't selected yes or no
+  if (!makeFormLive || !makeFormLive.length) {
+    errors['makeFormLive'] = {
+      text: 'Select no if you do not want to make your form live yet',
+      href: "#makeFormLive"
+    }
+  }
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  if(containsErrors) {
+    res.render('form-designer/make-your-form-live', { errors, errorList, containsErrors })
+  } else {
+    if(makeFormLive === 'yes') {
+      req.session.data.status = "Live" 
+      res.redirect('form-is-live')
+    } else {
+      res.redirect('create-form')
+    }
+  }
+})
+
 module.exports = router

--- a/app/views/form-designer/are-you-sure-you-want-to-edit-live-questions.html
+++ b/app/views/form-designer/are-you-sure-you-want-to-edit-live-questions.html
@@ -4,7 +4,7 @@
 {% set pageQuestion = 'Are you sure you want to edit the questions?' %}
 
 {% block pageTitle %}
-  {{pageTitle}} - {{pageQuestion}} - GOV.UK Forms
+  {{ "Error: " if containsErrors }}{{pageTitle}} - {{pageQuestion}} - GOV.UK Forms
 {% endblock %}
 
 
@@ -13,6 +13,14 @@
 {% endblock %}
 
 {% block content %}
+
+{% if containsErrors %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList
+  }) }}
+{% endif %}
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -52,7 +60,8 @@
             value: "no",
             text: "No"
           }
-        ]
+        ],
+        errorMessage: { text: errors['editLiveQuestions'].text } if errors['editLiveQuestions'].text
       }) }}
 
       {{ govukButton({

--- a/app/views/form-designer/create-form.html
+++ b/app/views/form-designer/create-form.html
@@ -30,182 +30,179 @@
 {% endblock %}
 
 {% block content %}
-  <form id="form" class="form" action="../edit-page/{{ pageId }}" method="post">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
-        <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{pageTitle}}</h1>
-        {% if data['status'] %}
-        {{govukTag({
-          text: data['status'],
-          classes: "govuk-!-margin-bottom-7 govuk-tag--purple" if data['status'] === 'Draft' else "govuk-!-margin-bottom-7 govuk-tag--turquoise"
-        })}}
-        {% endif %}
+      <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
+      <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{pageTitle}}</h1>
+      {% if data['status'] %}
+      {{govukTag({
+        text: data['status'],
+        classes: "govuk-!-margin-bottom-7 govuk-tag--purple" if data['status'] === 'Draft' else "govuk-!-margin-bottom-7 govuk-tag--turquoise"
+      })}}
+      {% endif %}
 
-        <!-- Keep these for now. Could still be needed/of use -->
-        {% set nextPageId = data['highestPageId'] | int + 1 %}
-        {% set totalPageNum = data['highestPageId'] | int + 2 %}
+      <!-- Keep these for now. Could still be needed/of use -->
+      {% set nextPageId = data['highestPageId'] | int + 1 %}
+      {% set totalPageNum = data['highestPageId'] | int + 2 %}
 
-        {% if data['status'] === 'Live' %}
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form is live</h2>
-          <p class="govuk-body">The URL for your form is:</p>
-          <p class="govuk-body">
-            <input class="govuk-input" type="text" id="formURL" value="forms.service.gov.uk/example-url" style="background-color:#f3f2f1;border-color:#b1b4b6;">
-          </p>
-          <div class="tooltip">
-            <span class="tooltiptext govuk-body" id="copyURLTooltip">Copy to clipboard</span>
-            <button class="govuk-button govuk-button--secondary" type="button" onclick="copyURL()">
-              Copy URL
-            </button>
-          </div>
-        {% else %}
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form incomplete</h2>
-          <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{sections}} of 8 sections.</p>
-        {% endif %}
-
-        <ol class="app-task-list">
-          <li>
-            <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">1. </span> {% if data['status'] === 'Live' %}Edit your form{% else %}Create your form{% endif %}
-            </h2>
-            <ul class="app-task-list__items">
-              {% if data['status'] === 'Draft' %}
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="form-create-a-form" aria-describedby="name-of-form-status">
-                    Edit the name of your form
-                  </a>
-                </span>
-                <strong class="govuk-tag {% if not data['formTitle'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="name-of-form-status">{% if data['formTitle'] %}Completed{% else %}Not started{% endif %}</strong>
-              </li>
-              {% endif %}
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="{% if data['status'] === 'Live' %}are-you-sure-you-want-to-edit-live-questions{% else %}form-index{% endif %}" aria-describedby="add-questions-status">
-                    Add and edit your questions
-                  </a>
-                </span>
-                {% if data['status'] === 'Draft' %}
-                <strong class="govuk-tag {% if data.pages.length %}govuk-tag--blue{%else %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-questions-status">{% if data.pages.length %}In progress{% else %}Not started {% endif %}</strong>
-                {% endif %}
-              </li>
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="edit-page/check-answers" aria-describedby="add-declaration-status">
-                    Review summary page and add declaration
-                  </a>
-                </span>
-                {% if data['status'] === 'Draft' %}
-                <strong class="govuk-tag {% if not data['checkAnswersDeclaration'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-declaration-status">{% if not data['checkAnswersDeclaration'] %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
-              </li>
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="edit-page/confirmation" aria-describedby="add-what-happens-next-status">
-                    Add information about what happens next
-                  </a>
-                </span>
-                {% if data['status'] === 'Draft' %}
-                <strong class="govuk-tag {% if not data['confirmationNext'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-what-happens-next-status">{% if not data['confirmationNext'] %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
-              </li>
-            </ul>
-          </li>
-
-          <li>
-            <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">2. </span> Set form responses
-            </h2>
-            <ul class="app-task-list__items">
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="completed-forms-email/set-completed-forms-email" aria-describedby="processing-email-status">
-                    Set the email address completed forms will be sent to
-                  </a>
-                </span>
-                {% if data['status'] === 'Draft' %}
-                <strong class="govuk-tag {% if not data['formsEmail'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="processing-email-status">{% if data['formsEmail'] %}Completed{% else %}Not started{% endif %}</strong>
-                {% endif %}
-              </li>
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  {% if data['formsEmail'] or data['status'] === 'Live' %}<a href="completed-forms-email/add-confirmation-code" aria-describedby="verified-email-status">{% endif %}
-                    Enter the email address confirmation code
-                  {% if data['formsEmail'] or data['status'] === 'Live' %}</a>{% endif %}
-                </span>
-                {% if data['status'] === 'Draft' %}
-                <strong class="govuk-tag {% if not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}govuk-tag--grey{% endif %} app-task-list__tag" id="verified-email-status">{% if not data['formsEmail'] %}Cannot start yet{% elif not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
-              </li>
-            </ul>
-          </li>
-
-          <li>
-            <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">3. </span> Get your form ready to go live
-            </h2>
-            <ul class="app-task-list__items">
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <a href="#" aria-describedby="privacy-information-link-status">
-                    Provide a link to your privacy information
-                  </a>
-                </span>
-                {% if data['status'] === 'Draft' %}
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="privacy-information-link-status">Not started</strong>{% endif %}
-              </li>
-            </ul>
-          </li>
-
-          {% if data['status'] === 'Draft' %}
-          <li>
-            <h2 class="app-task-list__section">
-              <span class="app-task-list__section-number">4. </span> Make your form live
-            </h2>
-            <ul class="app-task-list__items">
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  {% if sections >= 7 -%}<a href="#" aria-describedby="form-live-status">{%- endif %}
-                    Make your form live
-                  {% if sections >= 7 -%}</a>{%- endif %}
-                </span>
-                {% if data['status'] === 'Live' -%}
-                <strong class="govuk-tag app-task-list__tag" id="form-live-status">Completed</strong>
-                {%- elif sections >= 7 -%}
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Not started</strong>
-                {%- else -%}
-                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Cannot start yet</strong>
-                {%- endif %}
-              </li>
-            </ul>
-          </li>{% endif %}
-
-        </ol>
-
-        {% if data['status'] === 'Live' %}
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Publish your form on GOV.UK</h2>
+      {% if data['status'] === 'Live' %}
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form is live</h2>
+        <p class="govuk-body">The URL for your form is:</p>
         <p class="govuk-body">
-          Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+          <input class="govuk-input" type="text" id="formURL" value="forms.service.gov.uk/example-url" style="background-color:#f3f2f1;border-color:#b1b4b6;">
         </p>
-        {% endif %}
+        <div class="tooltip">
+          <span class="tooltiptext govuk-body" id="copyURLTooltip">Copy to clipboard</span>
+          <button class="govuk-button govuk-button--secondary" type="button" onclick="copyURL()">
+            Copy URL
+          </button>
+        </div>
+      {% else %}
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Form incomplete</h2>
+        <p class="govuk-body govuk-!-margin-bottom-7">You have completed {{sections}} of 8 sections.</p>
+      {% endif %}
 
-        {% if data['formTitle'] %}
-        <p class="govuk-body govuk-!-margin-top-9">
-          {{ govukButton({
-            text: "Delete form",
-            classes: "govuk-button--warning"
-          }) }}
-        </p>
-        {% endif %}
+      <ol class="app-task-list">
+        <li>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number">1. </span> {% if data['status'] === 'Live' %}Edit your form{% else %}Create your form{% endif %}
+          </h2>
+          <ul class="app-task-list__items">
+            {% if data['status'] === 'Draft' %}
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="form-create-a-form" aria-describedby="name-of-form-status">
+                  Edit the name of your form
+                </a>
+              </span>
+              <strong class="govuk-tag {% if not data['formTitle'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="name-of-form-status">{% if data['formTitle'] %}Completed{% else %}Not started{% endif %}</strong>
+            </li>
+            {% endif %}
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="{% if data['status'] === 'Live' %}are-you-sure-you-want-to-edit-live-questions{% else %}form-index{% endif %}" aria-describedby="add-questions-status">
+                  Add and edit your questions
+                </a>
+              </span>
+              {% if data['status'] === 'Draft' %}
+              <strong class="govuk-tag {% if data.pages.length %}govuk-tag--blue{%else %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-questions-status">{% if data.pages.length %}In progress{% else %}Not started {% endif %}</strong>
+              {% endif %}
+            </li>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="edit-page/check-answers" aria-describedby="add-declaration-status">
+                  Review summary page and add declaration
+                </a>
+              </span>
+              {% if data['status'] === 'Draft' %}
+              <strong class="govuk-tag {% if not data['checkAnswersDeclaration'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-declaration-status">{% if not data['checkAnswersDeclaration'] %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
+            </li>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="edit-page/confirmation" aria-describedby="add-what-happens-next-status">
+                  Add information about what happens next
+                </a>
+              </span>
+              {% if data['status'] === 'Draft' %}
+              <strong class="govuk-tag {% if not data['confirmationNext'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="add-what-happens-next-status">{% if not data['confirmationNext'] %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
+            </li>
+          </ul>
+        </li>
 
-      </div>
+        <li>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number">2. </span> Set form responses
+          </h2>
+          <ul class="app-task-list__items">
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="completed-forms-email/set-completed-forms-email" aria-describedby="processing-email-status">
+                  Set the email address completed forms will be sent to
+                </a>
+              </span>
+              {% if data['status'] === 'Draft' %}
+              <strong class="govuk-tag {% if not data['formsEmail'] %}govuk-tag--grey{% endif %} app-task-list__tag" id="processing-email-status">{% if data['formsEmail'] %}Completed{% else %}Not started{% endif %}</strong>
+              {% endif %}
+            </li>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                {% if data['formsEmail'] or data['status'] === 'Live' %}<a href="completed-forms-email/add-confirmation-code" aria-describedby="verified-email-status">{% endif %}
+                  Enter the email address confirmation code
+                {% if data['formsEmail'] or data['status'] === 'Live' %}</a>{% endif %}
+              </span>
+              {% if data['status'] === 'Draft' %}
+              <strong class="govuk-tag {% if not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}govuk-tag--grey{% endif %} app-task-list__tag" id="verified-email-status">{% if not data['formsEmail'] %}Cannot start yet{% elif not data['confirmationCode'] or (data['confirmationCode'] === '000000') %}Not started{% else %}Completed{% endif %}</strong>{% endif %}
+            </li>
+          </ul>
+        </li>
+
+        <li>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number">3. </span> Get your form ready to go live
+          </h2>
+          <ul class="app-task-list__items">
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <a href="#" aria-describedby="privacy-information-link-status">
+                  Provide a link to your privacy information
+                </a>
+              </span>
+              {% if data['status'] === 'Draft' %}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="privacy-information-link-status">Not started</strong>{% endif %}
+            </li>
+          </ul>
+        </li>
+
+        {% if data['status'] === 'Draft' %}
+        <li>
+          <h2 class="app-task-list__section">
+            <span class="app-task-list__section-number">4. </span> Make your form live
+          </h2>
+          <ul class="app-task-list__items">
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                {% if sections >= 5 -%}<a href="make-your-form-live" aria-describedby="form-live-status">{%- endif %}
+                  Make your form live
+                {% if sections >= 5 -%}</a>{%- endif %}
+              </span>
+              {% if data['status'] === 'Live' -%}
+              <strong class="govuk-tag app-task-list__tag" id="form-live-status">Completed</strong>
+              {%- elif sections >= 5 -%}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Not started</strong>
+              {%- else -%}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="form-live-status">Cannot start yet</strong>
+              {%- endif %}
+            </li>
+          </ul>
+        </li>{% endif %}
+
+      </ol>
+
+      {% if data['status'] === 'Live' %}
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Publish your form on GOV.UK</h2>
+      <p class="govuk-body">
+        Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+      </p>
+      {% endif %}
+
+      {% if data['formTitle'] %}
+      <p class="govuk-body govuk-!-margin-top-9">
+        {{ govukButton({
+          text: "Delete form",
+          classes: "govuk-button--warning"
+        }) }}
+      </p>
+      {% endif %}
+
     </div>
-  </form>
+  </div>
 
 {% endblock %}
 
 {% block pageScripts %}
 <script type="text/javascript">
   function copyURL() {
-    console.log('Hello')
     /* Get the text field */
     var copyText = document.getElementById("formURL");
 

--- a/app/views/form-designer/form-is-live.html
+++ b/app/views/form-designer/form-is-live.html
@@ -1,0 +1,57 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% block pageTitle %}
+  Your form is live: {{ data['formTitle'] }}
+{% endblock %}
+
+{% block content %}
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
+    <h1 class="govuk-heading-l">Your form is live</h1>
+
+    <p class="govuk-body">The URL for your form is:</p>
+    <p class="govuk-body">
+      <input class="govuk-input" type="text" id="formURL" value="forms.service.gov.uk/example-url" style="background-color:#f3f2f1;border-color:#b1b4b6;">
+    </p>
+    <div class="tooltip">
+      <span class="tooltiptext govuk-body" id="copyURLTooltip">Copy to clipboard</span>
+      <button class="govuk-button govuk-button--secondary" type="button" onclick="copyURL()">
+        Copy URL
+      </button>
+    </div>
+
+    <p class="govuk-body">
+      The form will not be indexed by search engines, so people will not be able to find it easily. Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it.
+    </p>
+
+    <a href="create-form" class="govuk-body govuk-link govuk-link--no-visited-state">Continue to form details</a>
+
+  </div>
+
+</div>
+
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript">
+  function copyURL() {
+    /* Get the text field */
+    var copyText = document.getElementById("formURL");
+
+    /* Select the text field */
+    copyText.select();
+    copyText.setSelectionRange(0, 99999); /* For mobile devices */
+
+     /* Copy the text inside the text field */
+    navigator.clipboard.writeText(copyText.value);
+
+    /* Alert the copied text */
+    var tooltip = document.getElementById("copyURLTooltip");
+    tooltip.innerHTML = "Copied to clipboard";
+  }
+</script>
+{% endblock %}

--- a/app/views/form-designer/make-your-form-live.html
+++ b/app/views/form-designer/make-your-form-live.html
@@ -1,0 +1,92 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Make your form live' %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }} {{pageTitle}} - {{ data['formTitle'] }} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="create-form">Back to create a form</a>
+{% endblock %}
+
+{% block content %}
+
+{% if containsErrors %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList
+  }) }}
+{% endif %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-l">{{ data['formTitle'] }}</span>
+    <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+    <p class="govuk-body">
+      When you make your form live you will get a URL for the form. The form will not be indexed by search engines, so people will not be able to find it easily. Contact your GOV.UK publishing team to publish a link to your form on GOV.UK so people can find it. 
+    <p>
+
+    <p class="govuk-body">
+      Make sure you are happy with the form before you make it live. After you have made your form live:
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          completed forms will be sent to [the email address they provided]
+        </li>
+        <li>
+          you will not be able to change the name of the form.
+        </li>
+      </ul>
+    </p>
+
+    {% set html %}
+    <p class="govuk-notification-banner__heading">
+      Any changes you make to a live form will be updated in the form immediately.
+    </p>
+    <p class="govuk-body">
+      This could have an impact on people who are filling in the form at the same time. They may lose any answers they have already provided and may need to start again. 
+    </p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: html
+    }) }}
+
+    <form method="post">
+        {{ govukRadios({
+          classes: "govuk-radios--inline",
+          idPrefix: "makeFormLive",
+          name: "makeFormLive",
+          fieldset: {
+            legend: {
+              text: "Are you sure you want to make your form live?",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes"
+            },
+            {
+              value: "no",
+              text: "No"
+            }
+          ],
+          errorMessage: { text: errors['makeFormLive'].text } if errors['makeFormLive'].text
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+    </form>
+
+  </div>
+
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Based on [Mural mockups](https://app.mural.co/t/gaap0347/m/gaap0347/1652697480711/fa60d6e36c472088d3c49ea4a7e7fc5b1d8186d4?wid=0-1659349599412)

Add a link to make form live page
Small tweak to the logic to allow access to making form live link a bit faster
Removed `form` tag

Add make form live and form is live pages
When you make the form live it changes the form status to Live and all related tags

Add errors to pages

## Journey and pages change

### Create a form with draft status tag ( from previous PR)
![screencapture-localhost-3000-form-designer-create-form-2022-08-10-14_20_05](https://user-images.githubusercontent.com/2632224/183911715-2222e634-ca10-45a2-80cc-3d4115110896.png)

### Make form live yes/no page
![screencapture-localhost-3000-form-designer-make-your-form-live-2022-08-10-14_16_44](https://user-images.githubusercontent.com/2632224/183911828-9ef3d8b7-ea31-4dd5-90c2-44190f15b199.png)

### Form is live yay!
![screencapture-localhost-3000-form-designer-form-is-live-2022-08-10-14_17_00](https://user-images.githubusercontent.com/2632224/183911903-c931e78f-3aa7-4347-9266-e0fa4655e5c9.png)

### Back to the Your form page with a 'Live' status tag
![screencapture-localhost-3000-form-designer-create-form-2022-08-10-14_22_20](https://user-images.githubusercontent.com/2632224/183912161-33f6b582-3e61-40c6-aa87-1eb532d75bb9.png)

