### PR TITLE
'Edit question' page content tweaks

### DIFF
--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -112,7 +112,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "Ask a question the way you would in person. For example ‘What is your address?’."
+            text: "Ask a question the way you would in person. For example ‘What is your address?’"
           },
           formGroup: {
             classes: "govuk-!-margin-bottom-3"
@@ -130,7 +130,7 @@
             classes: "govuk-label--m"
           },
           hint: {
-            text: "You can use hint text if you need to explain the format the answer should be in, or where to find the information you’ve asked for."
+            text: "Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for."
           },
           id: "hint-text",
           name: namePrefix + "[hint-text]",
@@ -214,7 +214,7 @@
               text: "Date",
               checked: checked(namePrefix + "['type']", "date"),
               hint: {
-                text: "Requires a specific day, month and year"
+                text: "Requires a day, month and year"
               }
             },
             {


### PR DESCRIPTION
I've made three small changes: 

1. 
Removed full stop on ‘Question text’ hint because it already has a question mark.

2. 
CHANGED:
You can use hint text if you need to explain the format the answer should be in, or where to find the information you’ve asked for.
TO:
Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for.
WHY:
More descriptive. This needed to be better since we shortened the label to just 'Hint text'.  

3.
CHANGED:
Requires a specific day, month and year
TO:
Requires a day, month and year
WHY:
To avoid people thinking it will only accept one specific date. 