### PR TITLE
121 design how to get form creators to provide a url for a page with privacy information for their form

### DIFF
--- a/app/data/returning-session-data-defaults.js
+++ b/app/data/returning-session-data-defaults.js
@@ -81,7 +81,7 @@ module.exports = {
       pageIndex: '7'
     }
   ],
-  status: 'Live',
+  status: 'Draft',
   confirmationTitle: 'Your form has been submitted',
   checkAnswersTitle: 'Check your answers before submitting your form',
   formTitle: 'Amendment form: redundancy claim for holiday pay'

--- a/app/routes.js
+++ b/app/routes.js
@@ -423,11 +423,34 @@ router.post('/form-designer/make-your-form-live', function (req, res) {
     res.render('form-designer/make-your-form-live', { errors, errorList, containsErrors })
   } else {
     if(makeFormLive === 'yes') {
-      req.session.data.status = "Live" 
+      req.session.data.status = "Live"
       res.redirect('form-is-live')
     } else {
       res.redirect('create-form')
     }
+  }
+})
+
+router.post('/form-designer/provide-link-to-privacy-information', function (req, res) {
+  const errors = {};
+  const { privacyInformation } = req.session.data
+
+  // If the user haven't selected yes or no
+  if (!privacyInformation?.length) {
+    errors['privacyInformation'] = {
+      text: 'Enter a link to privacy information',
+      href: "#privacy-information"
+    }
+  }
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  if(containsErrors) {
+    res.render('form-designer/provide-link-to-privacy-information', { errors, errorList, containsErrors })
+  } else {
+    res.redirect('create-form')
   }
 })
 

--- a/app/views/form-designer/create-form.html
+++ b/app/views/form-designer/create-form.html
@@ -144,12 +144,12 @@
           <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <a href="#" aria-describedby="privacy-information-link-status">
+                <a href="provide-link-to-privacy-information" aria-describedby="privacy-information-link-status">
                   Provide a link to your privacy information
                 </a>
               </span>
               {% if data['status'] === 'Draft' %}
-              <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="privacy-information-link-status">Not started</strong>{% endif %}
+              <strong class="govuk-tag {% if not data['privacyInformation']%} govuk-tag--grey {%endif%} app-task-list__tag" id="privacy-information-link-status">{% if not data['privacyInformation']%}Not started{% else %} Completed {% endif %}</strong>{% endif %}
             </li>
           </ul>
         </li>

--- a/app/views/form-designer/make-your-form-live.html
+++ b/app/views/form-designer/make-your-form-live.html
@@ -31,16 +31,16 @@
 
     <p class="govuk-body">
       Make sure you are happy with the form before you make it live. After you have made your form live:
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>
-          completed forms will be sent to [the email address they provided]
-        </li>
-        <li>
-          you will not be able to change the name of the form.
-        </li>
-      </ul>
     </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        completed forms will be sent to {{data['formsEmail'] or 'email@address.com' | safe}}
+      </li>
+      <li>
+        you will not be able to change the name of the form
+      </li>
+    </ul>
+
 
     {% set html %}
     <p class="govuk-notification-banner__heading">

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "layout-govuk-form-preview.html" %}
 {% set mainClasses = "main--draft govuk-main-wrapper--auto-spacing" %}
 
 {% block header %}

--- a/app/views/form-designer/provide-link-to-privacy-information.html
+++ b/app/views/form-designer/provide-link-to-privacy-information.html
@@ -1,0 +1,80 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Provide a link to privacy information for this form' %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }}{{pageTitle}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="{{data['referer']}}">Back your form</a>
+{% endblock %}
+
+{% block content %}
+
+{% if containsErrors %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList
+  }) }}
+{% endif %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">
+      {{pageTitle}}
+    </h1>
+
+    <p class="govuk-body">
+      To comply with the UK General Data Protection Regulation (UK GDPR), you must provide privacy information for the people who will enter their data into your form.
+    </p>
+
+    <p class="govuk-body">
+      The privacy information must include details such as: 
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          your purposes for processing the personal data
+        </li>
+        <li>
+          how long you’ll keep the personal data
+        </li>
+        <li>
+          who the data will be shared with
+        </li>
+        <li>
+          contact details for your department and your data protection officer
+        </li>
+      </ul>
+    </p>
+
+    <p class="govuk-body">
+      You may already publish this information, for example in a privacy notice or personal information charter. Existing privacy information may need to be updated to cover the data you are collecting in this form, or you may need a new privacy notice. 
+    </p>
+
+    <p class="govuk-body">
+      To get help, contact your department’s data protection officer or data protection manager.
+    </p>
+
+    <form method="post">
+      {{ govukInput({
+        label: {
+          text: "Enter a link to privacy information for this form",
+          classes: "govuk-label--m"
+        },
+        classes: "govuk-!-width-two-thirds",
+        id: "privacy-information",
+        name: "privacyInformation",
+        errorMessage: { text: errors['privacyInformation'].text } if errors['privacyInformation'].text
+      }) }}
+
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+
+
+{% endblock %}

--- a/app/views/form-designer/provide-link-to-privacy-information.html
+++ b/app/views/form-designer/provide-link-to-privacy-information.html
@@ -65,7 +65,11 @@
         classes: "govuk-!-width-two-thirds",
         id: "privacy-information",
         name: "privacyInformation",
-        errorMessage: { text: errors['privacyInformation'].text } if errors['privacyInformation'].text
+        hint: {
+          text: "For example, https://www.gov.uk/help/privacy-notice"
+        },
+        errorMessage: {
+          text: errors['privacyInformation'].text } if errors['privacyInformation'].text
       }) }}
 
       {{ govukButton({

--- a/app/views/layout-govuk-form-preview.html
+++ b/app/views/layout-govuk-form-preview.html
@@ -1,0 +1,87 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"           import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"           import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"         import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"              import govukButton %}
+{% from "govuk/components/character-count/macro.njk"     import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"          import govukCheckboxes %}
+{% from "govuk/components/cookie-banner/macro.njk"       import govukCookieBanner %}
+{% from "govuk/components/date-input/macro.njk"          import govukDateInput %}
+{% from "govuk/components/details/macro.njk"             import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"       import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"       import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"            import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"         import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"               import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"          import govukInsetText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/panel/macro.njk"               import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"        import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"              import govukRadios %}
+{% from "govuk/components/select/macro.njk"              import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"           import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"        import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"               import govukTable %}
+{% from "govuk/components/tabs/macro.njk"                import govukTabs %}
+{% from "govuk/components/tag/macro.njk"                 import govukTag %}
+{% from "govuk/components/textarea/macro.njk"            import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"        import govukWarningText %}
+
+{% block head %}
+  {% include "includes/head.html" %}
+{% endblock %}
+
+{% block pageTitle %}
+  GOV.UK Prototype Kit
+{% endblock %}
+
+{% block header %}
+  {# Set serviceName in config.js. #}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: "{{ data['formTitle']}}",
+    serviceUrl: "/",
+    containerClasses: "govuk-width-container"
+  }) }}
+{% endblock %}
+
+{% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
+
+{% if useAutoStoreData %}
+  {% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: "#",
+            text: "Get help with this form"
+          },
+          {
+            href: "#",
+            text: "Privacy"
+          },
+          {
+            href: "https://www.forms.service.gov.uk/accessibility/",
+            text: "Accessibility"
+          },
+          {
+            href: "#",
+            text: "Cookies"
+          }
+        ]
+      }
+    }) }}
+  {% endblock %}
+{% endif %}
+
+{% block bodyEnd %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+{% endblock %}


### PR DESCRIPTION
[Trello card](https://trello.com/c/5hf54nQf)

[Design based on Mural area](https://app.mural.co/t/gaap0347/m/gaap0347/1652697480711/fa60d6e36c472088d3c49ea4a7e7fc5b1d8186d4?wid=0-1659598224882)

# Relevant user story

As a form creator, I need to create a privacy notice for my form, so the people completing it know why we're asking for the information how we will process it, and to meet GDPR.

## Why are we working on this user story this sprint?

- The department that uses GOV.UK Forms is the ‘data controller’ and they have to provide information about the data they collect and how they manage it to meet the requirements of GDPR.

## Hypothesis

**If we** ask the form creator to provide a link to privacy information for a form before they can make a form live
**then** they will be able to provide a ink to privacy information for their form
**then** including privacy notice will become part of the form creation process and we can provide a link to the privacy information alongside the form

**If we** include guidance about what privacy information needs to be provided and why it is needed
**then** users will feel more confident in what it needs to cover, how to provide a link to one or how to get one created.

## Test

We’ll proceed if users are confident in providing a link to privacy information for their form

# Page changes

## New page to add privacy information
![screencapture-localhost-3000-form-designer-provide-link-to-privacy-information-2022-08-11-16_47_21](https://user-images.githubusercontent.com/2632224/184176286-5cae5939-5383-457d-b171-029c6d44cd7d.png)

## Fixes to Make your form live page
To address previous PR 😄 

![screencapture-localhost-3000-form-designer-make-your-form-live-2022-08-11-16_48_40](https://user-images.githubusercontent.com/2632224/184176878-b8c118e3-1acb-4c3a-beca-7e516459db80.png)


