### PR TITLE
Content updates to setting email address

### DIFF
--- a/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
+++ b/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
@@ -16,9 +16,13 @@
       <h1 class="govuk-heading-l">{{pageTitle|safe}}</h1>
 
       <p class="govuk-body">
-        We've sent a confirmation code and your email address to {{data['formsEmail'] or 'email@address.com' | safe}}. The recipient will be asked to give you the code. You need to enter the code to confirm the email address. The code is valid for 7 days.
+        We've sent a confirmation code and your email address to {{data['formsEmail'] or 'email@address.com' | safe}}.
       </p>
-
+      
+      <p class="govuk-body">
+        The recipient will be asked to give you the code. You need to enter the code to confirm the email address. The code is valid for 7 days.
+      </p>
+      
       <p class="govuk-body">
          <a href="add-confirmation-code" class="govuk-link">Enter the email address confirmation code</a>
       </p>

--- a/app/views/form-designer/completed-forms-email/set-completed-forms-email.html
+++ b/app/views/form-designer/completed-forms-email/set-completed-forms-email.html
@@ -24,11 +24,15 @@
       <h1 class="govuk-heading-l">{{pageTitle|safe}}</h1>
 
       <p class="govuk-body">
-        This should be a shared government email inbox.
+        You need to provide an email address for completed forms to be sent to for processing. It should be a shared government email inbox. 
       </p>
 
       <p class="govuk-body">
-        An email will be sent to this address with a confirmation code and your email address. The recipient will be asked to tell you the code. You will then need to enter the code to confirm the email address.
+        To make sure the email address you provide is correct, we’ll send an email to it with a confirmation code and your email address.
+      </p>
+
+      <p class="govuk-body">
+        The recipient will be asked to tell you the code. You will then need to enter the code to confirm the email address.
       </p>
 
       <form method="post">


### PR DESCRIPTION
Content updates following usability testing to make this content more descriptive and clearer. Have provided more reasoning for asking for the email address and the need to confirm it.

