### PR TITLE
Content updates for declaration

### DIFF
--- a/app/views/form-designer/create-form.html
+++ b/app/views/form-designer/create-form.html
@@ -98,7 +98,7 @@
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <a href="edit-page/check-answers" aria-describedby="add-declaration-status">
-                  Review summary page and add declaration
+                  Add a declaration for people to agree to
                 </a>
               </span>
               {% if data['status'] === 'Draft' %}

--- a/app/views/form-designer/edit-check-answers-page.html
+++ b/app/views/form-designer/edit-check-answers-page.html
@@ -1,6 +1,6 @@
 {% extends "layout-govuk-forms.html" %}
 
-{% set pageTitle = 'Form summary page' %}
+{% set pageTitle = 'Add a declaration' %}
 
 {% block pageTitle %}
   {{ "Error: " if containsErrors }}Edit {{pageTitle|lower}} - GOV.UK Forms
@@ -43,9 +43,13 @@
       #}
       {% set pagePrefix = "p" + pageId + "-" %}
 
-      <p class="govuk-body">This page lists all the questions and answers so people can check them before they submit the form.</p>
+      <p class="govuk-body">When someone has answered all the questions in your form, they will be shown a page that lists all of their answers. The page will ask them to check their answers before they submit the form.</p>
 
-      <p class="govuk-body">You can add a declaration for people to confirm their answers. For example:</p>
+      <p class="govuk-body">You can add a declaration to this page. A declaration is some content that people must confirm they understand and agree to before they submit the form.</p>
+      
+      <p class="govuk-body">You might want to add a declaration if you need people to confirm they have provided accurate information, or that they understand the consequences of providing false information.</p>
+      
+      <h2 class="govuk-heading-s">Example</h2>
 
       {{ govukInsetText({
         text: "By submitting this form you are confirming that, to the best of your knowledge, the answers you are providing are correct."
@@ -57,7 +61,7 @@
         maxlength: 2000,
         value: data['checkAnswersDeclaration'],
         label: {
-          text: "Declaration",
+          text: "Add a declaration for people to agree to (optional)",
           classes: "govuk-label--m"
         },
         errorMessage: { text: errors['checkAnswersDeclaration'].text } if errors['checkAnswersDeclaration'].text

--- a/app/views/form-designer/edit-check-answers-page.html
+++ b/app/views/form-designer/edit-check-answers-page.html
@@ -61,7 +61,7 @@
         maxlength: 2000,
         value: data['checkAnswersDeclaration'],
         label: {
-          text: "Add a declaration for people to agree to (optional)",
+          text: "Enter a declaration for people to agree to (optional)",
           classes: "govuk-label--m"
         },
         errorMessage: { text: errors['checkAnswersDeclaration'].text } if errors['checkAnswersDeclaration'].text


### PR DESCRIPTION
Content improvement based on findings from usability testing in sprint 9. Changes have been made to: 

- focus on providing declaration content (that’s the action) rather than on checking answers - made the task list link text, heading and content more specific
- make it clearer that the declaration is for people who are completing the form to agree to
- add an example heading to make it clearer what the example is, and to be consistent with the pattern on the 'what happens next' page.
- make the label text more descriptive and clear
