### PR TITLE
New separate answer type page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -47,6 +47,29 @@ router.use('/form-designer/*', function (req, res, next) {
   next();
 })
 
+router.get('/form-designer/edit-answer-type/:pageId', function (req, res) {
+  var action = req.session.data.action
+  var pageId = req.params.pageId
+
+  // If user pressed the 'Update preview' button or back link...
+  var pageIndex = parseInt(pageId) - 1
+  var pageData = req.session.data.pages[pageIndex]
+
+  // Update the 'Highest page Id'
+  req.session.data.highestPageId = req.session.data.pages.length
+
+  if (action == 'editPage') {
+    res.redirect('/form-designer/edit-page/' + pageId)
+  } else {
+    res.render('form-designer/edit-answer-type', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      editingExistingQuestion: req.session.data.pages[pageIndex] !== undefined
+    })
+  }
+})
+
 // Renders the page editor, set to a specific page
 router.get('/form-designer/edit-page/:pageId', function (req, res) {
   var action = req.session.data.action
@@ -156,6 +179,7 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
     res.render('form-designer/edit-page', {
       pageId: pageId,
       pageIndex: pageIndex,
+      typeData: req.session.data.pages.type,
       pageData: pageData,
       editingExistingQuestion: req.session.data.pages[pageIndex] !== undefined,
       enableMultipleChoiceAnswerType
@@ -226,7 +250,7 @@ router.get('/form-designer/reorder-page/:pageId/:direction', function (
 // Renders the page type chooser, set to a specific page
 router.get('/form-designer/choose-page-type/:pageId', function (req, res) {
   req.session.data.action = ''
-  res.redirect(`/form-designer/edit-page/${req.params.pageId}`)
+  res.redirect(`/form-designer/edit-answer-type/${req.params.pageId}`)
 })
 
 // Renders the in-page preview, set to a specific page

--- a/app/views/form-designer/edit-answer-type.html
+++ b/app/views/form-designer/edit-answer-type.html
@@ -1,0 +1,142 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle -%}
+  {% if pageData['long-title'] %}
+    {{pageData['long-title']}}
+  {% else %}
+    Edit question
+  {% endif %}
+{%- endset %}
+
+{% block pageTitle %}
+  {{pageTitle|safe}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  {% set prevPageId = pageId | int - 1 %}
+  {% if prevPageId > 0 %}
+    <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
+  {% else %}
+    <a class="govuk-back-link" href="../form-index" target="_parent">Back</a>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+
+  <form id="form" class="form" action="../edit-answer-type/{{pageId}}" method="post">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-l">Question {{pageId}}</span>
+
+        {% set namePrefix = "pages[" + pageIndex + "]" %}
+
+        {%
+          set radioItems = [
+            {
+              value: "text",
+              text: "Single line of text",
+              checked: checked(namePrefix + "['type']", "text") or allEmpty,
+              hint: {
+                text: "For a short answer"
+              }
+            },
+            {
+              value: "textarea",
+              text: "Multiple lines of text",
+              checked: checked(namePrefix + "['type']", "textarea"),
+              hint: {
+                text: "For a longer answer"
+              }
+            },
+            {
+              value: "number",
+              text: "Number",
+              checked: checked(namePrefix + "['type']", "number"),
+              hint: {
+                text: "Requires a numerical answer"
+              }
+            },
+            {
+              value: "address",
+              text: "Address",
+              checked: checked(namePrefix + "['type']", "address"),
+              hint: {
+                text: "To collect an address with separate fields for line 1, line 2, town or city, county and postcode"
+              }
+            },
+            {
+              value: "date",
+              text: "Date",
+              checked: checked(namePrefix + "['type']", "date"),
+              hint: {
+                text: "Requires a day, month and year"
+              }
+            },
+            {
+              value: "email",
+              text: "Email address",
+              checked: checked(namePrefix + "['type']", "email"),
+              hint: {
+                text: "Requires an answer in the format of an email address"
+              }
+            },
+            {
+              value: "national-insurance-number",
+              text: "National Insurance number",
+              checked: checked(namePrefix + "['type']", "national-insurance-number"),
+              hint: {
+                text: "Requires an answer in the format of a National Insurance number"
+              }
+            },
+            {
+              value: "phone",
+              text: "Phone number",
+              checked: checked(namePrefix + "['type']", "phone"),
+              hint: {
+                text: "Requires an answer in the format of a phone number"
+              }
+            }
+          ]
+        %}
+
+        {{ govukRadios({
+          idPrefix: "type",
+          name: namePrefix + "[type]",
+          classes: "govuk-radios--small",
+          fieldset: {
+            legend: {
+              text: "What kind of answer do you need to this question?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            text: "The answer will be checked to make sure it’s in the selected format."
+          },
+          items: radioItems
+        }) }}
+
+        <input type="hidden" id="long-title" name="{{namePrefix}}[long-title]" value="{{pageData['long-title']}}">
+        <input type="hidden" id="hint-text" name="{{namePrefix}}[hint-text]" value="{{pageData['hint-text']}}">
+        <input type="hidden" id="index" name="{{namePrefix}}[pageIndex]'" value="{{[pageIndex]}}">
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Save and continue",
+            name: "action",
+            value: "editPage"
+          }) }}
+        </div>
+
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state" href="../form-index">Go to form overview</a>
+        </p>
+
+      </div>
+
+    </div>
+
+  </form>
+
+{% endblock %}

--- a/app/views/form-designer/edit-answer-type.html
+++ b/app/views/form-designer/edit-answer-type.html
@@ -14,8 +14,10 @@
 
 {% block beforeContent %}
   {% set prevPageId = pageId | int - 1 %}
-  {% if prevPageId > 0 %}
-    <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
+  {% if ('edit-page' in data.referer) and (pageId === data.referer.split('/') | last) %}
+    <a class="govuk-back-link" href="../edit-page/{{pageId}}">Back</a>
+  {% elif prevPageId > 0 %}
+    <a class="govuk-back-link" href="../edit-page/{{prevPageId}}">Back</a>
   {% else %}
     <a class="govuk-back-link" href="../form-index" target="_parent">Back</a>
   {% endif %}

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -15,7 +15,7 @@
 {% block beforeContent %}
   {% set prevPageId = pageId | int - 1 %}
   {% if prevPageId > 0 %}
-    <a class="govuk-back-link" href="{{prevPageId}}">Back</a>
+    <a class="govuk-back-link" href="../edit-answer-type/{{pageId}}">Back</a>
   {% else %}
     <a class="govuk-back-link" href="../form-index" target="_parent">Back</a>
   {% endif %}

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -27,83 +27,10 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        {% set namePrefix = "pages[" + pageIndex + "]" %}
-
         <span class="govuk-caption-l">Question {{pageId}}</span>
         <h1 class="govuk-heading-l">{{pageTitle|safe}}</h1>
 
-        {% set radioCheckboxHtml %}
-
-        {{ govukTextarea({
-          label: {
-            text: "Option list",
-            classes: "govuk-label--s"
-          },
-          hint: {
-            text: "Enter each item on a new line"
-          },
-          id: "item-list",
-          name: namePrefix + "[item-list]",
-          value: pageData['item-list'],
-          classes: "govuk-!-margin-bottom-1",
-          formGroup: {
-            classes: "govuk-!-margin-bottom-1"
-          }
-        }) }}
-
-        {{ govukCheckboxes({
-          idPrefix: "radios",
-          name: namePrefix + "[radios]",
-          classes: "govuk-checkboxes--small",
-          items: [
-            {
-              value: "radios",
-              text: "Only let people select one option",
-              checked: checked(namePrefix + "['radios']", "radios")
-            }
-          ]
-        }) }}
-
-       {% endset -%}
-
-    {# We're not using character limit for the textarea options yet #}
-      {# {% set textareaHtml %}
-        {{ govukSelect({
-          id: "char-limit",
-          name: namePrefix + "[char-limit]",
-          label: {
-            text: "Character limit",
-            classes: "govuk-label--s"
-          },
-          items: [
-            {
-              value: "none",
-              text: "None",
-              selected: checked(namePrefix + "['char-limit']", "")
-            },
-            {
-              value: "100",
-              text: "100",
-              selected: checked(namePrefix + "['char-limit']", "100")
-            },
-            {
-              value: "250",
-              text: "250",
-              selected: checked(namePrefix + "['char-limit']", "250")
-            },
-            {
-              value: "500",
-              text: "500",
-              selected: checked(namePrefix + "['char-limit']", "500")
-            },
-            {
-              value: "750",
-              text: "750",
-              selected: checked(namePrefix + "['char-limit']", "750")
-            }
-          ]
-        }) }}
-        {% endset -%} #}
+        {% set namePrefix = "pages[" + pageIndex + "]" %}
 
         <!-- Long question text input -->
         {{ govukInput({
@@ -114,16 +41,12 @@
           hint: {
             text: "Ask a question the way you would in person. For example ‘What is your address?’"
           },
-          formGroup: {
-            classes: "govuk-!-margin-bottom-3"
-          },
           id: "long-title",
           name: namePrefix + "[long-title]",
           value: pageData['long-title']
         }) }}
 
-        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
+        <!-- Hint text input -->
         {{ govukInput({
           label: {
             text: "Hint text (optional)",
@@ -137,187 +60,25 @@
           value: pageData['hint-text']
         }) }}
 
-        {# <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Add help text
-            </span>
-          </summary>
-          <div class="govuk-details__text govuk-!-padding-bottom-0">
-            {{ govukTextarea({
-              id: "help-text",
-              name: namePrefix + "[help-text]",
-              value: pageData['help-text'],
-              classes: "govuk-!-margin-bottom-1",
-              label: {
-                text: "Help",
-                classes: "govuk-visually-hidden"
-              },
-              hint: {
-                text: "More detailed help — only add this if people get stuck"
-              }
-            }) }}
-          </div>
-        </details> #}
-
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-        {# If no type is set, set type to text #}
-        {%
-         set allEmpty = not (checked(namePrefix + "['type']", "text")
-           or checked(namePrefix + "['type']", "number")
-           or checked(namePrefix + "['type']", "email")
-           or checked(namePrefix + "['type']", "address")
-           or checked(namePrefix + "['type']", "phone")
-           or checked(namePrefix + "['type']", "national-insurance-number")
-           or checked(namePrefix + "['type']", "date"))
-        %}
-
-        {%
-          set radioItems = [
-            {
-              value: "text",
-              text: "Single line of text",
-              checked: checked(namePrefix + "['type']", "text") or allEmpty,
-              hint: {
-                text: "For a short answer"
-              }
-            },
-            {
-              value: "textarea",
-              text: "Multiple lines of text",
-              checked: checked(namePrefix + "['type']", "textarea"),
-              hint: {
-                text: "For a longer answer"
-              }
-            },
-            {
-              value: "number",
-              text: "Number",
-              checked: checked(namePrefix + "['type']", "number"),
-              hint: {
-                text: "Requires a numerical answer"
-              }
-            },
-            {
-              value: "address",
-              text: "Address",
-              checked: checked(namePrefix + "['type']", "address"),
-              hint: {
-                text: "To collect an address with separate fields for line 1, line 2, town or city, county and postcode"
-              }
-            },
-            {
-              value: "date",
-              text: "Date",
-              checked: checked(namePrefix + "['type']", "date"),
-              hint: {
-                text: "Requires a day, month and year"
-              }
-            },
-            {
-              value: "email",
-              text: "Email address",
-              checked: checked(namePrefix + "['type']", "email"),
-              hint: {
-                text: "Requires an answer in the format of an email address"
-              }
-            },
-            {
-              value: "national-insurance-number",
-              text: "National Insurance number",
-              checked: checked(namePrefix + "['type']", "national-insurance-number"),
-              hint: {
-                text: "Requires an answer in the format of a National Insurance number"
-              }
-            },
-            {
-              value: "phone",
-              text: "Phone number",
-              checked: checked(namePrefix + "['type']", "phone"),
-              hint: {
-                text: "Requires an answer in the format of a phone number"
-              }
-            }
-          ]
-        %}
-
-        {% set multipleChoiceRadioItem = {
-            value: "radio-checkbox",
-            text: "Choosing from a list of options",
-            checked: checked(namePrefix + "['type']", "radio-checkbox"),
-            conditional: {
-              html: radioCheckboxHtml
-            }
-          }
-        %}
-
-        {% if enableMultipleChoiceAnswerType %}
-          {% set radioItems = (radioItems.push(multipleChoiceRadioItem), radioItems) %}
-        {% endif %}
-
-        {{ govukRadios({
-          idPrefix: "type",
-          name: namePrefix + "[type]",
-          classes: "govuk-radios--small",
-          fieldset: {
-            legend: {
-              text: "What kind of answer do you need to this question?",
-              classes: "govuk-fieldset__legend--m"
-            }
-          },
-          hint: {
-            text: "The answer will be checked to make sure it’s in the selected format."
-          },
-          items: radioItems
-        }) }}
-
-        {# Keeping this textarea section for now in case we want to try out and test setting character limit in the future #}
-        {#
-            {
-              value: "textarea",
-              text: "One or more paragraphs",
-              checked: checked(namePrefix + "['type']", "textarea"),
-              conditional: {
-                html: textareaHtml
-              }
-            },
-            {
-              value: "radio-checkbox",
-              text: "Choosing from a list of options",
-              checked: checked(namePrefix + "['type']", "radio-checkbox"),
-              conditional: {
-                html: radioCheckboxHtml
-              }
-            }, #}
-
-        {# <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-        <details class="govuk-details govuk-!-margin-bottom-0" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Add an introduction
-            </span>
-          </summary>
-          <div class="govuk-details__text govuk-!-padding-bottom-0">
-            {{ govukTextarea({
-              id: "intro-text",
-              name: namePrefix + "[intro-text]",
-              value: pageData['intro-text'],
-              classes: "govuk-!-margin-bottom-3",
-              label: {
-                text: "Introduction",
-                classes: "govuk-visually-hidden"
-              },
-              hint: {
-                text: "Only add if it helps people understand the question"
-              }
-            }) }}
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Answer type
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ pageData['type'] | capitalize | replace("-", " ") }}
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/edit-answer-type/{{pageIndex + 1}}">
+                Change <span class="govuk-visually-hidden">{{pageData['type']}}<span>
+              </a>
+            </dd>
           </div>
-        </details> #}
+        </dl>
 
+        <input type="hidden" id="type" name="{{namePrefix}}[type]'" value="{{pageData['type']}}">
         <input type="hidden" id="index" name="{{namePrefix}}[pageIndex]'" value="{{[pageIndex]}}">
 
         <div class="govuk-button-group">
@@ -347,12 +108,12 @@
           }) }}
 
           {% if editingExistingQuestion %}
-          {{ govukButton({
-            text: "Delete question",
-            classes: "govuk-button--warning",
-            name: "action",
-            value: "deletePage"
-          }) }}
+            {{ govukButton({
+              text: "Delete question",
+              classes: "govuk-button--warning",
+              name: "action",
+              value: "deletePage"
+            }) }}
           {% endif %}
         </div>
 


### PR DESCRIPTION
I think I've got this working, it's a little hacky but is able to pull through and edit questions and answer types with no impact to the preview journey