### PR TITLE
134 form creator can make lists to select from

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -171,6 +171,56 @@ router.get('/form-designer/edit-page/:pageId', function (req, res) {
     // reset the action to avoid a loop
     req.session.data.action = ''
     return res.redirect(`/form-designer/delete/${pageId}`)
+  } else if (action === 'addAnother') {
+    // If user pressed the 'Update preview' button or back link...
+    var pageIndex = parseInt(pageId) - 1
+    var pageData = req.session.data.pages[pageIndex]
+
+    var itemList = req.session.data.pages[pageIndex]['item-list']
+    var lastItem = itemList.length - 1
+
+    if (itemList[lastItem]) {
+      itemList.push("")
+    }
+
+    // reset the action to avoid a loop
+    req.session.data.action = ''
+    res.render('form-designer/edit-page', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      typeData: req.session.data.pages.type,
+      pageData: pageData,
+      editingExistingQuestion: req.session.data.pages[pageIndex] !== undefined,
+      enableMultipleChoiceAnswerType
+    })
+  } else if (action.includes('removeOption')) {
+
+    // If user pressed the 'Update preview' button or back link...
+    var pageIndex = parseInt(pageId) - 1
+    var pageData = req.session.data.pages[pageIndex]
+
+    var itemList = req.session.data.pages[pageIndex]['item-list']
+    var remove = req.session.data.action.split("-")
+    var itemToRemove = remove.pop()
+
+    if (itemToRemove > -1) { // only splice array when item is found
+      if (itemList.length <= 2) {
+        itemList.push("")
+      }
+      itemList.splice(itemToRemove, 1); // 2nd parameter means remove one item only
+    }
+
+    // reset the action to avoid a loop
+    req.session.data.action = ''
+    res.render('form-designer/edit-page', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      typeData: req.session.data.pages.type,
+      pageData: pageData,
+      editingExistingQuestion: req.session.data.pages[pageIndex] !== undefined,
+      enableMultipleChoiceAnswerType
+    })
+
   } else {
     // If user pressed the 'Update preview' button or back link...
     var pageIndex = parseInt(pageId) - 1

--- a/app/views/form-designer/check-answers-page-preview-new-tab.html
+++ b/app/views/form-designer/check-answers-page-preview-new-tab.html
@@ -29,7 +29,7 @@
       {% if questionTitle %}
 
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
+        <dt class="govuk-summary-list__key">
           <!--Q{{page["pageIndex"] | int + 1}}.--> {{questionTitle}}
         </dt>
         <dd class="govuk-summary-list__value">
@@ -44,6 +44,8 @@
               {% if data[loop.index + '-address-line-2'] %}{{data[loop.index + '-address-line-2']}}<br>{% endif %}
               {{data[loop.index + '-address-town']}}<br>
               {{data[loop.index + '-address-postcode']}}
+            {% elif page['type'] == 'select' and not page['oneOption'] %}
+              {{data[loop.index]|join(", ")}}
             {% else %}
               {{data[loop.index]}}
             {% endif %}
@@ -74,8 +76,13 @@
 
     {% endif %}
 
+    {% if data['checkAnswersDeclaration'] %}
+      {% set buttonText = 'Agree and submit' %}
+    {% else %}
+      {% set buttonText = 'Submit' %}
+    {% endif %}
     {{ govukButton({
-      text: "Agree and submit",
+      text: buttonText,
       href: "confirmation-page-preview-new-tab",
       attributes: {
         target: "_parent"

--- a/app/views/form-designer/check-answers-page-preview.html
+++ b/app/views/form-designer/check-answers-page-preview.html
@@ -47,8 +47,13 @@
       </div>
     {% endif %}
 
+    {% if data['checkAnswersDeclaration'] %}
+      {% set buttonText = 'Agree and submit' %}
+    {% else %}
+      {% set buttonText = 'Submit' %}
+    {% endif %}
     {{ govukButton({
-      text: "Agree and submit",
+      text: buttonText,
       disabled: true
     }) }}
 

--- a/app/views/form-designer/confirmation-page-preview-new-tab.html
+++ b/app/views/form-designer/confirmation-page-preview-new-tab.html
@@ -18,17 +18,15 @@
       <h1 class="govuk-panel__title">{{ data['confirmationTitle'] }} <span class="govuk-visually-hidden">preview</span></h1>
     </div>
 
-
-    <h2 class="govuk-heading-m">What happens next</h2>
-    
     {% if data['confirmationNext'] %}
-    <div class="app-prose-scope">
-    {% markdown %}
-      {{ data['confirmationNext'] }}
-    {% endmarkdown %}
-    </div>
-
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <div class="app-prose-scope">
+      {% markdown %}
+        {{ data['confirmationNext'] }}
+      {% endmarkdown %}
+      </div>
     {% endif %}
+    
   </div>
 </div>
 {% endblock %}

--- a/app/views/form-designer/edit-answer-type.html
+++ b/app/views/form-designer/edit-answer-type.html
@@ -96,6 +96,22 @@
               hint: {
                 text: "Requires an answer in the format of a phone number"
               }
+            },
+            {
+              value: "select",
+              text: "One or more selected options from a list",
+              checked: checked(namePrefix + "['type']", "select"),
+              hint: {
+                text: "Create a list of options for people to select from"
+              }
+            },
+            {
+              value: "yesorno",
+              text: "Yes or no",
+              checked: checked(namePrefix + "['type']", "yesorno"),
+              hint: {
+                text: "People have to select either yes or no"
+              }
             }
           ]
         %}

--- a/app/views/form-designer/edit-answer-type.html
+++ b/app/views/form-designer/edit-answer-type.html
@@ -31,6 +31,8 @@
 
         <span class="govuk-caption-l">Question {{pageId}}</span>
 
+        {% set namePrefix = "pages[" + pageIndex + "]" %}
+
         {%
           set radioItems = [
             {

--- a/app/views/form-designer/edit-answer-type.html
+++ b/app/views/form-designer/edit-answer-type.html
@@ -31,8 +31,6 @@
 
         <span class="govuk-caption-l">Question {{pageId}}</span>
 
-        {% set namePrefix = "pages[" + pageIndex + "]" %}
-
         {%
           set radioItems = [
             {

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -13,8 +13,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% set prevPageId = pageId | int - 1 %}
-  {% if prevPageId > 0 %}
+  {% if ('edit-answer-type' in data.referer) and (pageId === data.referer.split('/') | last) %}
     <a class="govuk-back-link" href="../edit-answer-type/{{pageId}}">Back</a>
   {% else %}
     <a class="govuk-back-link" href="../form-index" target="_parent">Back</a>

--- a/app/views/form-designer/edit-page.html
+++ b/app/views/form-designer/edit-page.html
@@ -8,12 +8,30 @@
   {% endif %}
 {%- endset %}
 
+{% if pageData['type'] === 'text' %}
+{% set answerType = 'Single line of text' %}
+{% elif pageData['type'] === 'textarea' %}
+{% set answerType = 'Multiple lines of text' %}
+{% elif pageData['type'] === 'email' %}
+{% set answerType = 'Email address' %}
+{% elif pageData['type'] === 'national-insurance-number' %}
+{% set answerType = 'National Insurance number' %}
+{% elif pageData['type'] === 'phone' %}
+{% set answerType = 'Phone number' %}
+{% elif pageData['type'] === 'select' %}
+{% set answerType = 'One or more selected options from a list' %}
+{% elif pageData['type'] === 'yesorno' %}
+{% set answerType = 'Yes or no' %}
+{% else %}
+{% set answerType = pageData['type']|capitalize %}
+{% endif %}
+
 {% block pageTitle %}
   {{pageTitle|safe}} - GOV.UK Forms
 {% endblock %}
 
 {% block beforeContent %}
-  {% if ('edit-answer-type' in data.referer) and (pageId === data.referer.split('/') | last) %}
+  {% if data.referer and ('edit-answer-type' in data.referer) and (pageId === data.referer.split('/') | last) %}
     <a class="govuk-back-link" href="../edit-answer-type/{{pageId}}">Back</a>
   {% else %}
     <a class="govuk-back-link" href="../form-index" target="_parent">Back</a>
@@ -67,7 +85,7 @@
               Answer type
             </dt>
             <dd class="govuk-summary-list__value">
-              {{ pageData['type'] | capitalize | replace("-", " ") }}
+              {{answerType}}
             </dd>
             <dd class="govuk-summary-list__actions">
               <a class="govuk-link govuk-link--no-visited-state" href="/form-designer/edit-answer-type/{{pageIndex + 1}}">
@@ -76,6 +94,52 @@
             </dd>
           </div>
         </dl>
+
+        {% if pageData['type'] === 'select' %}
+        <h2 class="govuk-heading-m">Edit your list of options</h2>
+        {{ govukCheckboxes({
+          idPrefix: "oneOption",
+          name: namePrefix + "[oneOption]",
+          fieldset: {
+            legend: {
+              text: "People can only select one option"
+            }
+          },
+          items: [
+            {
+              value: "oneOption",
+              text: "People can only select one option",
+              checked: checked(namePrefix + "['oneOption']", "oneOption")
+            }
+          ]
+        }) }}
+
+        {% set optionArray = pageData['item-list'] or [{},{}] %}
+        <ol class="govuk-list">
+        {% for option in optionArray %}
+          {% set optionRow -%}option{{loop.index0}}{%- endset %}
+          <li>
+            <label class="govuk-label" for="option-{{loop.index0}}">
+              Option {{loop.index}}
+            </label>
+            <input class="govuk-input govuk-input--width-20" id="option-{{loop.index0}}" name="{{namePrefix}}[item-list]" type="text" value="{{pageData['item-list'][loop.index0]}}">
+            {{ govukButton({
+              text: "Remove",
+              name: "action",
+              value: "removeOption-" + loop.index0,
+              classes: "govuk-button--secondary govuk-!-margin-bottom-3"
+            }) }}
+          </li>
+        {% endfor %}
+        </ol>
+
+        {{ govukButton({
+          text: "Add another option",
+          name: "action",
+          value: "addAnother",
+          classes: "govuk-button--secondary"
+        }) }}
+        {% endif %}
 
         <input type="hidden" id="type" name="{{namePrefix}}[type]'" value="{{pageData['type']}}">
         <input type="hidden" id="index" name="{{namePrefix}}[pageIndex]'" value="{{[pageIndex]}}">
@@ -127,7 +191,7 @@
           <h2 class="govuk-heading-m">
             Question preview
           </h2>
-          <a href="../page-preview-new-tab/{{pageId}}" class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-4 new-tab-link" target="_blank">Preview question in a new tab</a>
+          <!-- <a href="../page-preview-new-tab/{{pageId}}" class="govuk-link govuk-link--no-visited-state govuk-!-margin-bottom-4 new-tab-link" target="_blank">Preview question in a new tab</a> -->
           <div class="preview-header">
             <p class="preview-link govuk-body-s">
               <!-- <a href="#" target="_blank" onclick="document.getElementById('form').submit();">Refresh</a> &nbsp;|&nbsp; -->

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -264,9 +264,9 @@
         {% endif %}
 
         {# Checkboxes #}
-        {% if pageData['type'] == 'radio-checkbox' and not pageData['radios'] %}
+        {% if pageData['type'] == 'select' and not pageData['radios'] %}
 
-          {% set itemsArray = pageData['item-list'].split('\n') %}
+          {# {% set itemsArray = pageData['item-list'].split('\n') %} #}
 
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset" aria-describedby="question-1-hint">
@@ -283,15 +283,23 @@
                 {{ pageData['hint-text']}}
               </div>
               <div class="govuk-checkboxes">
-                {% for itemRaw in itemsArray %}
-                  {% set item = itemRaw | trim %}
+                {% if pageData['item-list'] %}
+                  {% for item in itemsArray %}
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">
+                    <input class="govuk-checkboxes__input" id="question-1-{{ item }}" name="question-1-" type="checkbox" value="{{ item }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="question-1-{{ item }}">
                       {{ item }}
                     </label>
                   </div>
-                {% endfor %}
+                  {% endfor %}
+                {% else %}
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">
+                    <i>Blank</i>
+                  </label>
+                </div>
+                {% endif %}
               </div>
             </fieldset>
           </div>

--- a/app/views/form-designer/page-preview-new-tab.html
+++ b/app/views/form-designer/page-preview-new-tab.html
@@ -230,12 +230,16 @@
         #}
 
         {# Radios #}
-        {% if pageData['type'] == 'radio-checkbox' and pageData['radios'] %}
+        {% if (pageData['type'] === 'select' and pageData['oneOption']) or (pageData['type'] === 'yesorno') %}
 
-          {% set itemsArray = pageData['item-list'].split('\n') %}
+          {% if pageData['type'] === 'yesorno' %}
+            {% set itemsArray = ['Yes', 'No'] %}
+          {% else %}
+            {% set itemsArray = pageData['item-list'] %}
+          {% endif %}
 
           <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="question-1-hint">
+            <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
 
               {% if not pageData['intro-text'] %}
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -245,7 +249,7 @@
                 </legend>
               {% endif %}
 
-              <div id="question-1-hint" class="govuk-hint">
+              <div id="question-{{pageId}}-hint" class="govuk-hint">
                 {{ pageData['hint-text']}}
               </div>
               <div class="govuk-radios">
@@ -253,7 +257,7 @@
                 {% set item = itemRaw | trim %}
                   <div class="govuk-radios__item">
                     <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}" {{ checked(pageId, item) }}>
-                    <label class="govuk-label govuk-radios__label" for="{{ pageId }}">
+                    <label class="govuk-label govuk-radios__label" for="{{ pageId }}-{{ item }}">
                       {{ item }}
                     </label>
                   </div>
@@ -264,12 +268,12 @@
         {% endif %}
 
         {# Checkboxes #}
-        {% if pageData['type'] == 'select' and not pageData['radios'] %}
+        {% if pageData['type'] == 'select' and not pageData['oneOption'] %}
 
-          {# {% set itemsArray = pageData['item-list'].split('\n') %} #}
+          {% set itemsArray = pageData['item-list'] %}
 
           <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="question-1-hint">
+            <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
 
               {% if not pageData['intro-text'] %}
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -279,15 +283,15 @@
                 </legend>
               {% endif %}
 
-              <div id="question-1-hint" class="govuk-hint">
+              <div id="question-{{pageId}}-hint" class="govuk-hint">
                 {{ pageData['hint-text']}}
               </div>
               <div class="govuk-checkboxes">
                 {% if pageData['item-list'] %}
                   {% for item in itemsArray %}
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="question-1-{{ item }}" name="question-1-" type="checkbox" value="{{ item }}">
-                    <label class="govuk-label govuk-checkboxes__label" for="question-1-{{ item }}">
+                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
                       {{ item }}
                     </label>
                   </div>
@@ -295,7 +299,13 @@
                 {% else %}
                 <div class="govuk-checkboxes__item">
                   <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                    <i>Blank</i>
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
                     <i>Blank</i>
                   </label>
                 </div>

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -187,9 +187,13 @@
         #}
 
         {# Radios #}
-        {% if pageData['type'] == 'radio-checkbox' and pageData['radios'] %}
+        {% if (pageData['type'] === 'select' and pageData['oneOption']) or (pageData['type'] === 'yesorno') %}
 
-        {% set itemsArray = pageData['item-list'].split('\n') %}
+          {% if pageData['type'] === 'yesorno' %}
+            {% set itemsArray = ['Yes', 'No'] %}
+          {% else %}
+            {% set itemsArray = pageData['item-list'] %}
+          {% endif %}
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" aria-describedby="question-1-hint">
@@ -220,9 +224,9 @@
         {% endif %}
 
         {# Checkboxes #}
-        {% if pageData['type'] == 'select' and not pageData['radios'] %}
+        {% if pageData['type'] == 'select' and not pageData['oneOption'] %}
 
-        {# {% set itemsArray = pageData['item-list'].split('\n') %} #}
+        {% set itemsArray = pageData['item-list'] %}
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" aria-describedby="question-1-hint">
@@ -249,6 +253,12 @@
               </div>
               {% endfor %}
             {% else %}
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+              <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">
+                <i>Blank</i>
+              </label>
+            </div>
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
               <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">

--- a/app/views/form-designer/page-preview.html
+++ b/app/views/form-designer/page-preview.html
@@ -220,9 +220,9 @@
         {% endif %}
 
         {# Checkboxes #}
-        {% if pageData['type'] == 'radio-checkbox' and not pageData['radios'] %}
+        {% if pageData['type'] == 'select' and not pageData['radios'] %}
 
-        {% set itemsArray = pageData['item-list'].split('\n') %}
+        {# {% set itemsArray = pageData['item-list'].split('\n') %} #}
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" aria-describedby="question-1-hint">
@@ -239,14 +239,23 @@
             {{ pageData['hint-text']}}
           </div>
           <div class="govuk-checkboxes">
-                {% for item in itemsArray %}
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="question-1-{{ item }}" name="question-1-" type="checkbox" value="{{ item }}">
-                  <label class="govuk-label govuk-checkboxes__label" for="question-1-{{ item }}">
-                    {{ item }}
-                  </label>
-                </div>
-                {% endfor %}
+            {% if pageData['item-list'] %}
+              {% for item in itemsArray %}
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="question-1-{{ item }}" name="question-1-" type="checkbox" value="{{ item }}">
+                <label class="govuk-label govuk-checkboxes__label" for="question-1-{{ item }}">
+                  {{ item }}
+                </label>
+              </div>
+              {% endfor %}
+            {% else %}
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+              <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}">
+                <i>Blank</i>
+              </label>
+            </div>
+            {% endif %}
           </div>
         </fieldset>
         </div>


### PR DESCRIPTION
This PR covers off the [designs from MURAL](https://app.mural.co/t/gaap0347/m/gaap0347/1652082094071/bd86d8544291bd649aa003aa1c9a94576e730bc6?wid=0-1661519078192)

New options added to answer type:

- One or more selected options from a list
- Yes or no

Add another option pattern added to Edit question page. This should allow user testing to add and remove multiple answers. Useful testing will be to check if users think the options save upon typing into the box or if they need to click a "Save..." button.

Other things fixed:

- removed "Preview this question in a new tab" link from Edit question page above in page preview
- hide "What happens next" title from confirmation pages if no text has been added to textarea
- update CYA button to reflect if no declaration has been add for example, button will default to "Submit" if declaration textarea is empty