### PR TITLE
Add hint text to answer types

### DIFF
--- a/app/views/form-designer/pages/edit-answer-type.html
+++ b/app/views/form-designer/pages/edit-answer-type.html
@@ -73,12 +73,18 @@
             {
               value: "select",
               text: "Selection from a list of options",
-              checked: checked(namePrefix + "['type']", "select")
+              checked: checked(namePrefix + "['type']", "select"),
+              hint: {
+                text: "You’ll be able to create a list of options for people to select from"
+              }
             },
             {
               value: "number",
               text: "Number",
-              checked: checked(namePrefix + "['type']", "number")
+              checked: checked(namePrefix + "['type']", "number"),
+              hint: {
+                text: "People will only be able to enter whole or decimal numbers"
+              }
             },
             {
               value: "text",


### PR DESCRIPTION
[
<img width="794" alt="Screenshot 2022-12-16 at 16 17 29" src="https://user-images.githubusercontent.com/2632224/208143157-807bdd1d-8967-4d2f-98d8-f9ca7620e9ad.png">
](url)

Adds hint text to number and select options from a list answer types