### PR TITLE
Change journey for create select from list question

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -253,14 +253,73 @@ router.post('/form-designer/pages/:pageId(\\d+)/edit-answer-type', function (req
       // date route
       return res.redirect('edit-settings')
     } else if (type === 'select') {
-      // selection from a list route
-      return res.redirect('edit-settings')
+      // what's your question route
+      return res.redirect('edit-select-question')
     } else if (type === 'text') {
       // text route
       return res.redirect('edit-settings')
     } else {
       return res.redirect('edit')
     }
+  }
+})
+
+// Edit a user-created answer type settings
+router.get('/form-designer/pages/:pageId(\\d+)/edit-select-question', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+  return res.render('form-designer/pages/edit-select-question', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData
+  })
+})
+
+// Route to what is your question page for select from list answer type
+router.post('/form-designer/pages/:pageId(\\d+)/edit-select-question', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  const type = req.session.data.type
+  req.session.data.type = undefined
+
+  const complete = req.session.data.isDeclarationComplete
+
+  const errors = {};
+  const title = req.session.data['long-title']
+
+  // if no question text given, then throw an error
+  if (!title || !title.length) {
+    errors['long-title'] = {
+      text: 'Enter your question',
+      href: "#long-title"
+    }
+  // otherwise add question text to pageData
+  } else {
+    pageData['long-title'] = req.session.data['long-title']
+  }
+  req.session.data['long-title'] = undefined
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  // If there are errors on the page, redisplay it with the errors
+  if(containsErrors) {
+    return res.render('form-designer/pages/edit-select-question', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      errors,
+      errorList,
+      containsErrors
+    })
+  } else {
+    const nextPageId = req.session.data.pages.length
+    res.redirect('edit-settings')
   }
 })
 

--- a/app/views/form-designer/pages/edit-answer-type.html
+++ b/app/views/form-designer/pages/edit-answer-type.html
@@ -122,9 +122,9 @@
           value: "editPage"
         }) }}
 
-        <p class="govuk-body">
+        {# <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
-        </p>
+        </p> #}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/edit-select-question.html
+++ b/app/views/form-designer/pages/edit-select-question.html
@@ -1,0 +1,86 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = "What's your question?" %}
+
+{% set answerType = pageData['type']|capitalize %}
+
+{% if pageData['type'] === 'select' %}
+  {% set answerType = 'Selection from a list' %}
+  {% if pageData['oneOption'] %}
+    {% set questionHint = data.selectionOneOptionQuestionHint %}
+  {% else %}
+    {% set questionHint = data.selectionMultipleOptionsQuestionHint %}
+  {% endif %}
+{% else %}
+  {% set questionHint = 'Ask a question the way you would in person. For example ‘What is your address?’' %}
+{% endif %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }}{{pageTitle}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+{% if data.referer and ('edit-answer-type' in data.referer) %}
+    <a class="govuk-back-link" href="edit-answer-type">
+      Back
+    </a>
+  {% elif data.referer and ('settings' in data.referer) %}
+    <a class="govuk-back-link" href="edit-settings">
+      Back
+    </a>
+  {% else %}
+  <a class="govuk-back-link" href="edit-answer-type">
+    Back
+  </a>
+{% endif%}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <form id="form" class="form" method="post" novalidate>
+          {% if containsErrors %}
+          {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errorList
+          }) }}
+          {% endif %}
+
+          <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
+
+          {% set namePrefix = "pages[" + pageIndex + "]" %}
+
+          <!-- Long question text input -->
+          {{ govukInput({
+            label: {
+               text: pageTitle,
+               classes: "govuk-label--l",
+               isPageHeading: true
+            },
+            hint: {
+              text: questionHint
+            },
+            id: "long-title",
+            name: "long-title",
+            value: pageData['long-title'],
+            errorMessage: { text: errors['long-title'].text } if errors['long-title'].text
+          }) }}
+
+          <div class="govuk-button-group">
+              {{ govukButton({
+                text: "Continue"
+              }) }}
+          </div>
+
+      </form>
+    </div>
+  </div>
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript">
+  // call function from `assets/javascripts/application.js`
+  // removeSuccessNotification();
+</script>
+{% endblock %}

--- a/app/views/form-designer/pages/edit-settings.html
+++ b/app/views/form-designer/pages/edit-settings.html
@@ -19,9 +19,23 @@
 {% endblock %}
 
 {% block beforeContent %}
+{% if data.referer and ('edit-answer-type' in data.referer) %}
+    <a class="govuk-back-link" href="edit-answer-type">
+      Back
+    </a>
+  {% elif data.referer and ('settings' in data.referer) %}
+    <a class="govuk-back-link" href="edit-settings">
+      Back
+    </a>
+  {% elif data.referer and ('edit-select-question' in data.referer) %}
+    <a class="govuk-back-link" href="edit-select-question">
+      Back
+    </a>
+  {% else %}
   <a class="govuk-back-link" href="edit-answer-type">
     Back
   </a>
+{% endif%}
 {% endblock %}
 
 {% block content %}
@@ -282,14 +296,14 @@
         {% endif %}
 
         {{ govukButton({
-          text: "Save and continue",
+          text: "Continue",
           name: "action",
           value: "editPage"
         }) }}
 
-        <p class="govuk-body">
+        {# <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
-        </p>
+        </p> #}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/edit.html
+++ b/app/views/form-designer/pages/edit.html
@@ -305,11 +305,12 @@
             name: "action",
             value: "deletePage"
           }) }}
-          {% endif %}
 
+          {# Move go to your questions link only if a question is saved #}
           <p class="govuk-body">
             <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
           </p>
+          {% endif %}
 
       </form>
     </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/fYZ69pYs)

We're looking to test an alternative way of creating a select from a list question, where we first let user specify their question and then add a list of options. We want to test if this flow is more intuitive for the users, as we learned from previous rounds of testing that some users were expecting to set their questions first and not the option list.

## Steps

### 1. User adds a question

### 2. User chooses 'Select form list of options' 

![Screenshot 2023-01-19 at 09 28 51](https://user-images.githubusercontent.com/2632224/213441032-5cbaaf72-e51e-4f31-a206-4a2935dffae7.png)

### 3. User specifies their question

![Screenshot 2023-01-19 at 11 55 21](https://user-images.githubusercontent.com/2632224/213441092-8966c6d1-8ec7-4ee6-9393-e72b8de76fbc.png)

### 4. User creates a list of options for answering the question
![Screenshot 2023-01-19 at 11 56 23](https://user-images.githubusercontent.com/2632224/213442144-5aa551ec-897a-45d4-a576-2ec5e6eb464c.png)

### 5. User can review, edit and save the question

![Screenshot 2023-01-19 at 11 56 45](https://user-images.githubusercontent.com/2632224/213441321-b1ffb88c-8daf-45af-a991-70bdefa8c45c.png)
