### PR TITLE
Add heading to confirmation code success page

### DIFF
--- a/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
+++ b/app/views/form-designer/completed-forms-email/confirmation-code-sent.html
@@ -20,12 +20,14 @@
       }) }}
 
       <p class="govuk-body">
-        We've sent a confirmation code and your email address to:
+        We’ve sent a confirmation code and your email address to:
       </p>
       
       <p class="govuk-body">
         {{data.formsEmail or 'email@address.com' | safe}}
       </p>
+      
+      <h2 class="govuk-heading-m">What you need to do next</h2>
 
       <p class="govuk-body">
         The recipient will be asked to give you the code. You need to enter the code to confirm the email address.


### PR DESCRIPTION
Added 'What you need to do next' heading to this page to highlight to users that there is another step to do to confirm the email address.