### PR TITLE
Add missing hint text to add declaration page

### DIFF
--- a/app/views/form-designer/pages/check-answers/edit.html
+++ b/app/views/form-designer/pages/check-answers/edit.html
@@ -86,6 +86,9 @@
               classes: "govuk-fieldset__legend--m"
             }
           },
+          hint: {
+          text: "Selecting ‘Yes’ will mark this task as complete. You will still be able to make more changes if you need to."
+          },
           items: [
             {
               value: "yes",

--- a/app/views/form-designer/pages/check-answers/edit.html
+++ b/app/views/form-designer/pages/check-answers/edit.html
@@ -87,7 +87,7 @@
             }
           },
           hint: {
-          text: "Selecting ‘Yes’ will mark this task as complete. You will still be able to make more changes if you need to."
+          text: "Selecting ‘Yes’ will mark this task as complete. You'll still be able to make more changes if you need to."
           },
           items: [
             {


### PR DESCRIPTION
So that it matches what we have in production

Trello:
https://trello.com/c/E6yQ39Ac