### PR TITLE
Remove store data workaround

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -267,25 +267,12 @@ var storeData = function (input, data) {
       if (index !== -1) {
         val.splice(index, 1)
       }
-      // Workaround for [Prototype Kit issue 693](https://github.com/alphagov/govuk-prototype-kit/issues/693)
-      // TODO: Remove this block when Prototype Kit issue is resolved or pages are no longer structured in an array
       if (i == 'pages') {
-        var editedPage = val[0]
-
-        // Store any nested objects
-        storeData(editedPage, editedPage)
-
-        // Replace existing page object if it exists
-        var filteredPages = data.pages.filter(
-          page => parseInt(page.pageIndex) !== parseInt(editedPage.pageIndex)
+        console.trace('Oops')
+        console.warn(
+          'If you are seeing this message in your prototype logs, then you\'ve reached some code I thought was unreachable...\n'
+          + 'Please update https://github.com/alphagov/forms-prototypes/pulls/183 with details of what you were doing and a copy of the log output above'
         )
-
-        // Add new page object to array and sort by page index
-        data.pages = [...filteredPages, editedPage].sort(
-          (a, b) => parseInt(a.pageIndex) - parseInt(b.pageIndex)
-        )
-
-        continue
       }
     } else if (typeof val === 'object') {
       // Store nested objects that aren't arrays


### PR DESCRIPTION
This workaround was needed to handle situations where we a form submits data named something like `pages[<n>][<key>]`.

However, in a subsequent commit (96fbeff), the routes that update the pages list were refactored, to make it easier for our designers to maintain [[1]].

I believe that this means that the workaround code in utils is no longer reachable, and can be removed. I have left a warning in case I'm wrong...

[1]: https://gds.slack.com/archives/C030K5706TX/p1678457780289839?thread_ts=1678444323.339829&cid=C030K5706TX