### PR TITLE
Change 'field' to 'box' for name question

### DIFF
--- a/app/views/form-designer/pages/edit-settings.html
+++ b/app/views/form-designer/pages/edit-settings.html
@@ -63,17 +63,17 @@
           set radioItems = [
             {
               value: "single-field",
-              text: "Full name in a single field",
+              text: "Full name in a single box",
               checked: checked(namePrefix + "['input']", "single-field")
             },
             {
               value: "multi-field",
-              text: "First and last names in separate fields",
+              text: "First and last names in separate boxes",
               checked: checked(namePrefix + "['input']", "multi-field")
             },
             {
               value: "multi-field-plus",
-              text: "First, middle and last names in separate fields",
+              text: "First, middle and last names in separate boxes",
               hint: {
                 text: 'Middle name will not be mandatory'
               },
@@ -92,7 +92,7 @@
             }
           },
           hint: {
-            text: 'A single name field is easiest for people to complete - only ask for names separately if you need the individual parts of the name.'
+            text: 'A single box for the full name is easiest for people to complete - only ask for names separately if you need the individual parts of the name.'
           },
           items: radioItems,
           errorMessage: { text: errors['input'].text } if errors['input'].text

--- a/app/views/form-designer/pages/edit.html
+++ b/app/views/form-designer/pages/edit.html
@@ -9,11 +9,11 @@
   {% set answerType = 'Person’s name' %}
   {% set inputTypeTitle = data.personNameInputTypeTitle %}
   {% if pageData['input'] === 'single-field' %}
-    {% set inputType = 'Full name in a single field' %}
+    {% set inputType = 'Full name in a single box' %}
   {% elif pageData['input'] === 'multi-field' %}
-    {% set inputType = 'First and last names in separate fields' %}
+    {% set inputType = 'First and last names in separate boxes' %}
   {% elif pageData['input'] === 'multi-field-plus' %}
-    {% set inputType = 'First, middle and last names in separate fields' %}
+    {% set inputType = 'First, middle and last names in separate boxes' %}
   {% endif %}
 {% elif pageData['type'] === 'companyName' %}
   {% set questionHint = data.companyNameQuestionHint %}


### PR DESCRIPTION
In user research we saw that the use of the word ‘field’ can be jarring and confusing for some. Box is a plainer language alternative.

This changes the use of 'field' in both the question and the playback of the question settings on the 'Edit question' page.