### PR TITLE
New detailed guidance journey created, ready for testing. 

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -602,18 +602,26 @@ router.get('/form-designer/pages/:pageId(\\d+)/additional-guidance', function (r
   var pageIndex = pageId
   var pageData = req.session.data.pages[pageIndex]
 
+  var successMessage = req.session.data.successMessage
+  req.session.data.successMessage = undefined
+
   var previousPage = req.session.data.referer
 
   return res.render('form-designer/pages/additional-guidance', {
     pageId: pageId,
     pageIndex: pageIndex,
     pageData: pageData,
+    successMessage,
     previousPage: previousPage
   })
 })
 
 // Add additional guidance text route
 router.post('/form-designer/pages/:pageId(\\d+)/additional-guidance', function (req, res) {
+  var action = req.session.data.action
+  // clear the action so it doesn't change the next page load
+  req.session.data.action = undefined
+
   var pageId = parseInt(req.params.pageId, 10)
   var pageIndex = pageId
   var pageData = req.session.data.pages[pageIndex]
@@ -625,13 +633,16 @@ router.post('/form-designer/pages/:pageId(\\d+)/additional-guidance', function (
   if (!guidanceText || !guidanceText.length) {
     errors['additional-guidance-text'] = {
       text: 'Enter guidance text',
-      href: "#additional-guidance-text"
+      href: "#edit-guidance-text"
     }
   // otherwise add guidance text to pageData
   } else {
     pageData['additional-guidance-text'] = req.session.data['additional-guidance-text']
   }
   req.session.data['additional-guidance-text'] = undefined
+
+  // content to display in notification banners
+  var previewing = 'Preview your guidance text'
 
   // Convert the errors into a list, so we can use it in the template
   const errorList = Object.values(errors)
@@ -648,6 +659,9 @@ router.post('/form-designer/pages/:pageId(\\d+)/additional-guidance', function (
       errorList,
       containsErrors
     })
+  } else if(action == 'previewGuidance') {
+    req.session.data.successMessage = previewing
+    res.redirect('additional-guidance#preview-guidance-text')
   } else {
     res.redirect('check-question')
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -561,8 +561,14 @@ router.post('/form-designer/pages/:pageId(\\d+)/edit', function (req, res) {
   }
   req.session.data['hint-text'] = undefined
 
-  // add additional guidance answer, add it to pageData
-  if (req.session.data['additional-guidance']) {
+  // if no additional guidance answer, then throw an error
+  if (!additionalGuidance || !additionalGuidance.length) {
+    errors['additional-guidance'] = {
+      text: 'Select ‘Yes’ to add guidance',
+      href: "#additional-guidance"
+    }
+  // otherwise add question text to pageData
+  } else {
     pageData['additional-guidance'] = req.session.data['additional-guidance']
   }
   req.session.data['additional-guidance'] = undefined

--- a/app/routes.js
+++ b/app/routes.js
@@ -20,9 +20,14 @@ const markdown = require('@lfdebrux/nunjucks-markdown')
 // Used to add govuk classes to additional guidance markdown for end user view (Runner)
 const { marked } = require('marked');
 const GovukHTMLRenderer = require('govuk-markdown')
+const renderer = new GovukHTMLRenderer()
+
+// Disable bold and italic formatting
+renderer.strong = text => text
+renderer.em = text => text
 
 marked.setOptions({
-  renderer: new GovukHTMLRenderer()
+  renderer
 })
 
 // One time setup

--- a/app/routes.js
+++ b/app/routes.js
@@ -546,19 +546,22 @@ router.post('/form-designer/pages/:pageId(\\d+)/edit', function (req, res) {
   var pageData = req.session.data.pages[pageIndex]
 
   const errors = {};
-  const title = req.session.data['long-title']
 
-  // if no question text given, then throw an error
-  if (!title || !title.length) {
-    errors['long-title'] = {
-      text: 'Enter a question',
-      href: "#long-title"
+  if (!pageData['long-title']) {
+    const title = req.session.data['long-title']
+
+    // if no question text given, then throw an error
+    if (!title || !title.length) {
+      errors['long-title'] = {
+        text: 'Enter a question',
+        href: "#long-title"
+      }
+    // otherwise add question text to pageData
+    } else {
+      pageData['long-title'] = req.session.data['long-title']
     }
-  // otherwise add question text to pageData
-  } else {
-    pageData['long-title'] = req.session.data['long-title']
+    req.session.data['long-title'] = undefined
   }
-  req.session.data['long-title'] = undefined
 
   // if hint text is added, add it to pageData
   if (req.session.data['hint-text']) {

--- a/app/views/form-designer/pages/additional-guidance.html
+++ b/app/views/form-designer/pages/additional-guidance.html
@@ -63,7 +63,7 @@
           <!-- Add detailed guidance input -->
           {{ govukTextarea({
             label: {
-              text: "Add detailed guidance",
+              text: "Add guidance text",
               classes: "govuk-label--m"
             },
             hint: {
@@ -72,7 +72,8 @@
             rows: 10,
             id: "edit-guidance-text",
             name: "additional-guidance-text",
-            value: pageData['additional-guidance-text']
+            value: pageData['additional-guidance-text'],
+            errorMessage: { text: errors['additional-guidance-text'].text } if errors['additional-guidance-text'].text 
           }) }}
 
 
@@ -114,7 +115,10 @@
 
           <h3 class="govuk-heading-s">Bulleted lists</h3>
           <p class="govuk-body">
-            To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash. For example:
+            To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash.
+          </p>
+          <p class="govuk-body">
+            You need one empty line space before the bullets start, and one at the end. For example:
           </p>
           {% set bullets = ['First bullet point','Second bullet point','Third bullet point'] %}
           <div class="govuk-inset-text">
@@ -128,7 +132,7 @@
             Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.
           </p>
           <p class="govuk-body">
-            You need one empty line space before the numbers start, and one at the end.
+            You need one empty line space before the numbers start, and one at the end. For example:
           </p>
           {% set numbered = ['First item','Second item','Third item'] %}
           <div class="govuk-inset-text">
@@ -144,7 +148,7 @@
             Preview your guidance text
           </h2>
           <p class="govuk-body">
-            Below is a preview of how your guidance content will be shown to the person completing your form.
+            Below is a preview of how your guidance content will be shown to the person completing the question.
           </p>
           <div class="govuk-!-margin-bottom-3" title="Preview area" style="position: relative; border: 2px solid #b1b4b6; padding: 30px;">
             {% markdown %}{{ pageData['additional-guidance-text'] }}{% endmarkdown %}

--- a/app/views/form-designer/pages/additional-guidance.html
+++ b/app/views/form-designer/pages/additional-guidance.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if 'check-question' in previousPage %}
+  {% if previousPage and ('check-question' in previousPage) %}
     <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>
@@ -31,6 +31,20 @@
             }) }}
           {% endif %}
 
+          {% if successMessage %}
+            {% set successHTML %}
+              <a class="govuk-notification-banner__link" href="#preview-guidance-text">
+                <h3 class="govuk-notification-banner__heading">
+                  {{successMessage}}
+                </h3>
+              </a>
+              {% endset %}
+            {{ govukNotificationBanner({
+              type: 'success',
+              html: successHTML
+            }) }}
+          {% endif %}
+
           <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
           <h1 class="govuk-heading-l">{{pageTitle}}</h1>
 
@@ -45,6 +59,7 @@
 
           {% set namePrefix = "pages[" + pageIndex + "]" %}
 
+
           <!-- Add detailed guidance input -->
           {{ govukTextarea({
             label: {
@@ -54,10 +69,21 @@
             hint: {
               text: "Use Markdown if you need to format your guidance content. Formatting help can be found below."
             },
-            id: "additional-guidance-text",
+            rows: 10,
+            id: "edit-guidance-text",
             name: "additional-guidance-text",
             value: pageData['additional-guidance-text']
           }) }}
+
+
+          <!-- Preview guidance text secondary button -->
+          {{ govukButton({
+            text: "Preview guidance",
+            classes: "govuk-button--secondary",
+            name: "action",
+            value: "previewGuidance"
+          }) }}
+
 
           <!-- Formatting help -->
           <h2 class="govuk-heading-m">Formatting help</h2>
@@ -90,11 +116,12 @@
           <p class="govuk-body">
             To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash. For example:
           </p>
-          {{ govukInsetText({
-            html: " * First bullet point<br>
-                    * Second bullet point<br>
-                    * Third bullet point"|safe
-          }) }}
+          {% set bullets = ['First bullet point','Second bullet point','Third bullet point'] %}
+          <div class="govuk-inset-text">
+            {% for bullet in bullets %}
+              * {{ bullet }}<br>
+            {% endfor %}
+          </div>
 
           <h3 class="govuk-heading-s">Numbered lists</h3>
           <p class="govuk-body">
@@ -103,20 +130,42 @@
           <p class="govuk-body">
             You need one empty line space before the numbers start, and one at the end.
           </p>
-          {{ govukInsetText({
-            html: " 1. First item<br>
-                    2. Second item<br>
-                    3. Third item"|safe
-          }) }}
+          {% set numbered = ['First item','Second item','Third item'] %}
+          <div class="govuk-inset-text">
+            {% for number in numbered %}
+              {{ loop.index }}. {{ number }}<br>
+            {% endfor %}
+          </div>
 
+
+          <!-- Preview guidance text -->
+          {% if pageData['additional-guidance-text'] %}
+          <h2 class="govuk-heading-m" id="preview-guidance-text">
+            Preview your guidance text
+          </h2>
+          <p class="govuk-body">
+            Below is a preview of how your guidance content will be shown to the person completing your form.
+          </p>
+          <div class="govuk-!-margin-bottom-3" title="Preview area" style="position: relative; border: 2px solid #b1b4b6; padding: 30px;">
+            {% markdown %}{{ pageData['additional-guidance-text'] }}{% endmarkdown %}
+          </div>
+          <p class="govuk-body govuk-!-margin-bottom-9">
+            <a class="govuk-link" href="#edit-guidance-text">
+              Edit guidance text
+            </a>
+          </p>
+          {% endif %}
+
+
+          <!-- Continue or cancel button group -->
           <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Continue",
-            name: "action",
-            value: "editPage"
-          }) }}
+            {{ govukButton({
+              text: "Continue",
+              name: "action",
+              value: "editPage"
+            }) }}
 
-          <a class="govuk-link govuk-link--no-visited-state" href="edit">Cancel</a>
+            <a class="govuk-link govuk-link--no-visited-state" href="edit">Cancel</a>
           </div>
 
       </form>

--- a/app/views/form-designer/pages/additional-guidance.html
+++ b/app/views/form-designer/pages/additional-guidance.html
@@ -1,0 +1,132 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Add guidance' %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }}{{pageTitle}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  {% if 'check-question' in previousPage %}
+    <a class="govuk-back-link" href="check-question" target="_parent">
+      Back
+    </a>
+  {% else %}
+    <a class="govuk-back-link" href="javascript:window.history.back()">
+      Back
+    </a>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form id="form" class="form" method="post" novalidate>
+
+          {% if containsErrors %}
+            {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: errorList
+            }) }}
+          {% endif %}
+
+          <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
+          <h1 class="govuk-heading-l">{{pageTitle}}</h1>
+
+          <p class="govuk-body">
+            Use guidance if you need to:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>explain how to answer the question in more detail</li>
+            <li>provide more context</li>
+            <li>format your content - for example, with links, sub-headings or lists</li>
+          </ul>
+
+          {% set namePrefix = "pages[" + pageIndex + "]" %}
+
+          <!-- Add detailed guidance input -->
+          {{ govukTextarea({
+            label: {
+              text: "Add detailed guidance",
+              classes: "govuk-label--m"
+            },
+            hint: {
+              text: "Use Markdown if you need to format your guidance content. Formatting help can be found below."
+            },
+            id: "additional-guidance-text",
+            name: "additional-guidance-text",
+            value: pageData['additional-guidance-text']
+          }) }}
+
+          <!-- Formatting help -->
+          <h2 class="govuk-heading-m">Formatting help</h2>
+
+          <h3 class="govuk-heading-s">Links and URLs</h3>
+          <p class="govuk-body">
+            To add a link, use square brackets [ ] around the link text, and round brackets ( ) around the full URL. For example:
+          </p>
+          {{ govukInsetText({
+            text: "[Link text](https://www.gov.uk/link-text-url)"
+          }) }}
+
+          <h3 class="govuk-heading-s">Second-level headings</h3>
+          <p class="govuk-body">
+            To add a second-level heading, use 2 hashtags followed by a space. For example:
+          </p>
+          {{ govukInsetText({
+            text: "## This is a second-level heading"
+          }) }}
+
+          <h3 class="govuk-heading-s">Third-level headings</h3>
+          <p class="govuk-body">
+            For a third-level heading, use 3 hashtags followed by a space. For example:
+          </p>
+          {{ govukInsetText({
+            text: "### This is a third-level heading"
+          }) }}
+
+          <h3 class="govuk-heading-s">Bulleted lists</h3>
+          <p class="govuk-body">
+            To add bullet points, start each item with * (asterisk) or - (dash). Use one space after the asterisk or dash. For example:
+          </p>
+          {{ govukInsetText({
+            html: " * First bullet point<br>
+                    * Second bullet point<br>
+                    * Third bullet point"|safe
+          }) }}
+
+          <h3 class="govuk-heading-s">Numbered lists</h3>
+          <p class="govuk-body">
+            Use numbers for each list item, followed by a full stop. Make sure there is one space after the full stop.
+          </p>
+          <p class="govuk-body">
+            You need one empty line space before the numbers start, and one at the end.
+          </p>
+          {{ govukInsetText({
+            html: " 1. First item<br>
+                    2. Second item<br>
+                    3. Third item"|safe
+          }) }}
+
+          <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Continue",
+            name: "action",
+            value: "editPage"
+          }) }}
+
+          <a class="govuk-link govuk-link--no-visited-state" href="edit">Cancel</a>
+          </div>
+
+      </form>
+    </div>
+  </div>
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript">
+  // call function from `assets/javascripts/application.js`
+  // removeSuccessNotification();
+</script>
+{% endblock %}

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -100,11 +100,11 @@
           Question
         </dt>
         <dd class="govuk-summary-list__value">
-          {{pageData['long-title']}}
+          {{ pageData['long-title'] or 'Question text' }}
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link govuk-link--no-visited-state" href="edit#long-title">
-            Change <span class="govuk-visually-hidden">question {{pageData['long-title']}}<span>
+            Change <span class="govuk-visually-hidden">question {{ pageData['long-title'] or 'Question text' }}<span>
           </a>
         </dd>
       </div>

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -1,0 +1,327 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Check your question' %}
+
+{% set answerType = pageData['type']|capitalize %}
+{% if pageData['type'] === 'personName' %}
+  {% set answerType = 'Person’s name' %}
+  {% set inputTypeTitle = data.personNameInputTypeTitle %}
+  {% if pageData['input'] === 'single-field' %}
+    {% set inputType = 'Full name in a single box' %}
+  {% elif pageData['input'] === 'multi-field' %}
+    {% set inputType = 'First and last names in separate boxes' %}
+  {% elif pageData['input'] === 'multi-field-plus' %}
+    {% set inputType = 'First, middle and last names in separate boxes' %}
+  {% endif %}
+{% elif pageData['type'] === 'companyName' %}
+  {% set answerType = 'Company or organisation’s name' %}
+{% elif pageData['type'] === 'email' %}
+  {% set answerType = 'Email address' %}
+{% elif pageData['type'] === 'phone' %}
+  {% set answerType = 'Phone number' %}
+{% elif pageData['type'] === 'national-insurance-number' %}
+  {% set answerType = 'National Insurance number' %}
+{% elif pageData['type'] === 'address' %}
+  {% set inputTypeTitle = data.addressInputTypeTitle %}
+  {% if ('uk-address' in pageData['input']) and ('international-address' in pageData['input']) %}
+    {% set inputType = 'UK and international addresses' %}
+  {% elif 'uk-address' in pageData['input'] %}
+    {% set inputType = 'UK addresses' %}
+  {% elif 'international-address' in pageData['input'] %}
+    {% set inputType = 'International addresses' %}
+  {% endif %}
+{% elif pageData['type'] === 'date' %}
+  {% set inputTypeTitle = data.dateOfBirthInputTypeTitle %}
+  {% if pageData['input'] === 'yes' %}
+    {% set inputType = 'Yes' %}
+  {% else %}
+    {% set inputType = 'No' %}
+  {% endif %}
+{% elif pageData['type'] === 'select' %}
+  {% set answerType = 'Selection from a list' %}
+{% elif pageData['type'] === 'number' %}
+{% elif pageData['type'] === 'text' %}
+  {% set inputTypeTitle = data.textLengthInputTypeTitle %}
+  {% if pageData['input'] === 'single-line-input' %}
+    {% set inputType = 'A single line of text' %}
+  {% else %}
+    {% set inputType = 'More than a single line of text' %}
+  {% endif %}
+{% endif %}
+
+{% block pageTitle %}
+  {{pageTitle}} - Preview - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+  {% if 'your-questions' in previousPage %}
+    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
+      Back to your questions
+    </a>
+  {% elif ('edit-answer-type' in previousPage) and (previousPage.split('/')|last == pageIndex|int + 1) %}
+    <a class="govuk-back-link" href="../{{pageIndex|int + 1}}/edit-answer-type" target="_parent">
+      Back
+    </a>
+  {% else %}
+    <a class="govuk-back-link" href="javascript:window.history.back()">
+      Back
+    </a>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <form id="form" class="form" method="post" novalidate>
+
+    {% if containsErrors %}
+      {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: errorList
+      }) }}
+    {% endif %}
+
+    {% if successMessage %}
+      {{ govukNotificationBanner({
+        type: 'success',
+        text: successMessage
+      }) }}
+    {% endif %}
+
+    <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
+    <h1 class="govuk-panel__title">{{pageTitle}}</h1>
+
+    <!-- Your question -->
+    <h2 class="govuk-heading-m">Your question</h2>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Question
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{pageData['long-title']}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit#long-title">
+            Change <span class="govuk-visually-hidden">question {{pageData['long-title']}}<span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Hint text (optional)
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{pageData['hint-text']}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit#hint-text">
+            Change <span class="govuk-visually-hidden">hint text {{pageData['hint-text']}}<span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Add more detail
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{pageData['additional-guidance'] or 'No'}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit#additional-guidance">
+            Change <span class="govuk-visually-hidden">add more detail {{pageData['additional-guidance']}}<span>
+          </a>
+        </dd>
+      </div>
+      {% if pageData['additional-guidance'] == 'Yes' %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Guidance text
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{pageData['additional-guidance-text']}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="additional-guidance">
+            Change <span class="govuk-visually-hidden">guidance text {{pageData['additional-guidance-text']}}<span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+    </dl>
+
+
+    <!-- Question settings -->
+    <h2 class="govuk-heading-m">Question settings</h2>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Make this question optional
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ 'Yes' if data['questionOptional'] else 'No' }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit">
+            Change <span class="govuk-visually-hidden">if question optional<span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- Answer settings -->
+    <h2 class="govuk-heading-m">Answer settings</h2>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Answer type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{answerType}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit-answer-type">
+            Change <span class="govuk-visually-hidden">answer type {{answerType}}<span>
+          </a>
+        </dd>
+      </div>
+      {% if pageData['input'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          {{inputTypeTitle}}
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{inputType}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#input">
+            Change <span class="govuk-visually-hidden">input type {{inputType}}<span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+      {% if pageData['title'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Title needed
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{pageData['title']|capitalize}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#title">
+            Change <span class="govuk-visually-hidden">title needed {{pageData['title']|capitalize}}<span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+      {% if pageData['item-list'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Options
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {% if (pageData['item-list']|length|int >= 1) %}
+            {% for item in pageData['item-list'] %}{{item}}{% if not loop.last %}, {% endif %}{% endfor %}
+          {% else %}
+            No options added
+          {% endif %}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#option-0">
+            Change <span class="govuk-visually-hidden">options<span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Only select one option
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') else 'No'}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#oneOption">
+            Change <span class="govuk-visually-hidden">only select one option<span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Include 'none of the above' option
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') else 'No'}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#noneOption">
+            Change <span class="govuk-visually-hidden">include 'none of the above' option<span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+    </dl>
+
+    {% if (pageData['additional-guidance'] == 'Yes') and (pageData['additional-guidance-text']) %}
+    <!-- Give your page a heading -->
+    {{ govukInput({
+      label: {
+        text: "Give your page a heading",
+        classes: "govuk-label--m"
+      },
+      hint: {
+        text: "Use a heading that’s a statement rather than a question - for example, ‘Interview needs’. This will be your main page heading."
+      },
+      id: "page-name",
+      name: "page-name",
+      value: pageData['page-name'],
+      errorMessage: { text: errors['page-name'].text } if errors['page-name'].text 
+    }) }}
+    {% endif %}
+
+    <div class="govuk-button-group">
+    {% if pageId >= data['highestPageId'] %}
+
+      {{ govukButton({
+        text: "Save and add next question",
+        name: "action",
+        value: "createNextPage"
+      }) }}
+
+    {% else %}
+
+      {{ govukButton({
+        text: "Save and edit next question",
+        name: "action",
+        value: "editNextPage"
+      }) }}
+
+    {% endif %}
+
+    {{ govukButton({
+      text:  "Save question",
+      name: "action",
+      value: "update",
+      classes: "govuk-button--secondary"
+    }) }}
+
+    </div>
+
+    {% if editingExistingQuestion %}
+      {{ govukButton({
+        text: "Delete question",
+        classes: "govuk-button--warning",
+        name: "action",
+        value: "deletePage"
+      }) }}
+
+      {# Move go to your questions link only if a question is saved #}
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
+      </p>
+    {% endif %}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -54,11 +54,11 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if 'your-questions' in previousPage %}
+  {% if previousPage and ('your-questions' in previousPage) %}
     <a class="govuk-back-link" href="../../clear-empty" target="_parent">
       Back to your questions
     </a>
-  {% elif ('edit-answer-type' in previousPage) and (previousPage.split('/')|last == pageIndex|int + 1) %}
+  {% elif previousPage and ('edit-answer-type' in previousPage) and (previousPage.split('/')|last == pageIndex|int + 1) %}
     <a class="govuk-back-link" href="../{{pageIndex|int + 1}}/edit-answer-type" target="_parent">
       Back
     </a>

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -113,7 +113,7 @@
           Hint text (optional)
         </dt>
         <dd class="govuk-summary-list__value">
-          {{pageData['hint-text']}}
+          {{pageData['hint-text'] or 'None added' }}
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link govuk-link--no-visited-state" href="edit#hint-text">
@@ -123,14 +123,14 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Add more detail
+          Add guidance
         </dt>
         <dd class="govuk-summary-list__value">
           {{pageData['additional-guidance'] or 'No'}}
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link govuk-link--no-visited-state" href="edit#additional-guidance">
-            Change <span class="govuk-visually-hidden">add more detail {{pageData['additional-guidance']}}<span>
+            Change <span class="govuk-visually-hidden">add guidance {{pageData['additional-guidance']}}<span>
           </a>
         </dd>
       </div>

--- a/app/views/form-designer/pages/edit-BACKUP.html
+++ b/app/views/form-designer/pages/edit-BACKUP.html
@@ -1,0 +1,330 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Edit question' %}
+
+{% set answerType = pageData['type']|capitalize %}
+{% if pageData['type'] === 'personName' %}
+  {% set questionHint = data.personNameQuestionHint %}
+  {% set hintHint = data.personNameHintHint %}
+  {% set answerType = 'Person’s name' %}
+  {% set inputTypeTitle = data.personNameInputTypeTitle %}
+  {% if pageData['input'] === 'single-field' %}
+    {% set inputType = 'Full name in a single box' %}
+  {% elif pageData['input'] === 'multi-field' %}
+    {% set inputType = 'First and last names in separate boxes' %}
+  {% elif pageData['input'] === 'multi-field-plus' %}
+    {% set inputType = 'First, middle and last names in separate boxes' %}
+  {% endif %}
+{% elif pageData['type'] === 'companyName' %}
+  {% set questionHint = data.companyNameQuestionHint %}
+  {% set hintHint = data.companyNameHintHint %}
+  {% set answerType = 'Company or organisation’s name' %}
+{% elif pageData['type'] === 'email' %}
+  {% set questionHint = data.emailQuestionHint %}
+  {% set hintHint = data.emailHintHint %}
+  {% set answerType = 'Email address' %}
+{% elif pageData['type'] === 'phone' %}
+  {% set questionHint = data.phoneQuestionHint %}
+  {% set hintHint = data.phoneHintHint %}
+  {% set answerType = 'Phone number' %}
+{% elif pageData['type'] === 'national-insurance-number' %}
+  {% set questionHint = data.ninoQuestionHint %}
+  {% set hintHint = data.ninoHintHint %}
+  {% set answerType = 'National Insurance number' %}
+{% elif pageData['type'] === 'address' %}
+  {% set questionHint = data.addressQuestionHint %}
+  {% set hintHint = data.addressHintHint %}
+  {% set inputTypeTitle = data.addressInputTypeTitle %}
+  {% if ('uk-address' in pageData['input']) and ('international-address' in pageData['input']) %}
+    {% set inputType = 'UK and international addresses' %}
+  {% elif 'uk-address' in pageData['input'] %}
+    {% set inputType = 'UK addresses' %}
+  {% elif 'international-address' in pageData['input'] %}
+    {% set inputType = 'International addresses' %}
+  {% endif %}
+{% elif pageData['type'] === 'date' %}
+  {% set inputTypeTitle = data.dateOfBirthInputTypeTitle %}
+  {% if pageData['input'] === 'yes' %}
+    {% set questionHint = data.dobQuestionHint %}
+    {% set hintHint = data.dobHintHint %}
+    {% set inputType = 'Yes' %}
+  {% else %}
+    {% set questionHint = data.dateQuestionHint %}
+    {% set hintHint = data.dateHintHint %}
+    {% set inputType = 'No' %}
+  {% endif %}
+{% elif pageData['type'] === 'select' %}
+  {% set answerType = 'Selection from a list' %}
+  {% if pageData['oneOption'] %}
+    {% set questionHint = data.selectionOneOptionQuestionHint %}
+    {% set hintHint = data.selectionOneOptionHintHint %}
+  {% else %}
+    {% set questionHint = data.selectionMultipleOptionsQuestionHint %}
+    {% set hintHint = data.selectionMultipleOptionsHintHint %}
+  {% endif %}
+{% elif pageData['type'] === 'number' %}
+  {% set questionHint = data.numberQuestionHint %}
+  {% set hintHint = data.numberHintHint %}
+{% elif pageData['type'] === 'text' %}
+  {% set inputTypeTitle = data.textLengthInputTypeTitle %}
+  {% if pageData['input'] === 'single-line-input' %}
+    {% set questionHint = data.textSingleLineQuestionHint %}
+    {% set hintHint = data.textSingleLineHintHint %}
+    {% set inputType = 'A single line of text' %}
+  {% else %}
+    {% set questionHint = data.textMultipleLinesQuestionHint %}
+    {% set hintHint = data.textMultipleLinesHintHint %}
+    {% set inputType = 'More than a single line of text' %}
+  {% endif %}
+{% else %}
+  {% set questionHint = 'Ask a question the way you would in person. For example ‘What is your address?’' %}
+  {% set hintHint = "Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for." %}
+  {% set inputTypeTitle = 'Input type' %}
+{% endif %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }}{{pageTitle}} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  {% if data.referer and ('edit-answer-type' in data.referer) %}
+    <a class="govuk-back-link" href="edit-answer-type">
+      Back
+    </a>
+  {% elif data.referer and ('settings' in data.referer) %}
+    <a class="govuk-back-link" href="edit-settings">
+      Back
+    </a>
+  {% else %}
+    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
+      Back to your questions
+    </a>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        {% if successMessage %}
+        {{ govukNotificationBanner({
+          type: 'success',
+          text: successMessage
+        }) }}
+        {% endif %}
+
+        <form id="form" class="form" method="post" novalidate>
+
+          {% if containsErrors %}
+          {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errorList
+          }) }}
+          {% endif %}
+
+          <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
+          <h1 class="govuk-heading-l">{{pageTitle}}</h1>
+
+          {% set namePrefix = "pages[" + pageIndex + "]" %}
+
+          <!-- Long question text input -->
+          {{ govukInput({
+            label: {
+              text: "Question text",
+              classes: "govuk-label--m"
+            },
+            hint: {
+              text: questionHint
+            },
+            id: "long-title",
+            name: "long-title",
+            value: pageData['long-title'],
+            errorMessage: { text: errors['long-title'].text } if errors['long-title'].text
+          }) }}
+
+          <!-- Hint text input -->
+          {{ govukInput({
+            label: {
+              text: "Hint text (optional)",
+              classes: "govuk-label--m"
+            },
+            hint: {
+              text: hintHint
+            },
+            id: "hint-text",
+            name: "hint-text",
+            value: pageData['hint-text']
+          }) }}
+
+           {% if pageData['type'] != 'select' %}
+
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+          {{ govukCheckboxes({
+            idPrefix: "questionOptional",
+            name: "questionOptional",
+            fieldset: {
+              legend: {
+                text: "Question settings",
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            items: [
+              {
+                value: "questionOptional",
+                text: "Make this question optional so people can skip it",
+                hint: {
+                  text: "‘(optional)’ will be added to the end of the question text"
+                },
+                checked: checked(namePrefix + "['questionOptional']", "questionOptional")
+              }
+            ]
+          }) }}
+
+          <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
+          {% endif %}
+
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Answer type
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{answerType}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-answer-type">
+                  Change <span class="govuk-visually-hidden">answer type {{answerType}}<span>
+                </a>
+              </dd>
+            </div>
+            {% if pageData['input'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                {{inputTypeTitle}}
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{inputType}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#input">
+                  Change <span class="govuk-visually-hidden">input type {{inputType}}<span>
+                </a>
+              </dd>
+            </div>
+            {% endif %}
+            {% if pageData['title'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Title needed
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{pageData['title']|capitalize}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#title">
+                  Change <span class="govuk-visually-hidden">title needed {{pageData['title']|capitalize}}<span>
+                </a>
+              </dd>
+            </div>
+            {% endif %}
+            {% if pageData['item-list'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Options
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if (pageData['item-list']|length|int >= 1) %}
+                  {% for item in pageData['item-list'] %}{{item}}{% if not loop.last %}, {% endif %}{% endfor %}
+                {% else %}
+                  No options added
+                {% endif %}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#option-0">
+                  Change <span class="govuk-visually-hidden">options<span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Only select one option
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') else 'No'}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#oneOption">
+                  Change <span class="govuk-visually-hidden">only select one option<span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Include 'none of the above' option
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') else 'No'}}
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#noneOption">
+                  Change <span class="govuk-visually-hidden">include 'none of the above' option<span>
+                </a>
+              </dd>
+            </div>
+            {% endif %}
+          </dl>
+
+          <div class="govuk-button-group">
+            {% if pageId >= data['highestPageId'] %}
+
+              {{ govukButton({
+                text: "Save and add next question",
+                name: "action",
+                value: "createNextPage"
+              }) }}
+
+            {% else %}
+
+              {{ govukButton({
+                text: "Save and edit next question",
+                name: "action",
+                value: "editNextPage"
+              }) }}
+
+            {% endif %}
+
+            {{ govukButton({
+              text:  "Save question",
+              name: "action",
+              value: "update",
+              classes: "govuk-button--secondary"
+            }) }}
+          </div>
+
+          {% if editingExistingQuestion %}
+          {{ govukButton({
+            text: "Delete question",
+            classes: "govuk-button--warning",
+            name: "action",
+            value: "deletePage"
+          }) }}
+
+          {# Move go to your questions link only if a question is saved #}
+          <p class="govuk-body">
+            <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
+          </p>
+          {% endif %}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}
+
+{% block pageScripts %}
+<script type="text/javascript">
+  // call function from `assets/javascripts/application.js`
+  // removeSuccessNotification();
+</script>
+{% endblock %}

--- a/app/views/form-designer/pages/edit-answer-type.html
+++ b/app/views/form-designer/pages/edit-answer-type.html
@@ -6,14 +6,29 @@
   {{ "Error: " if containsErrors }}{{pageTitle}} - GOV.UK Forms
 {% endblock %}
 
+{% set pageNumberTemp %}
+  {% for ref in data.referer.split('/') %}
+    {% if loop.index == loop.length - 1 %}{{ref}}{% endif %}
+  {% endfor %}
+{% endset %}
+
 {% block beforeContent %}
-  {% set prevPageId = pageId | int - 1 %}
-  {% if ('edit-page' in data.referer) and (pageId === data.referer.split('/') | last) %}
-    <a class="govuk-back-link" href="../{{pageId}}/edit-page">Back</a>
-  {% elif ('edit-page' in data.referer) and (prevPageId > 0) %}
-    <a class="govuk-back-link" href="../{{prevPageId}}/edit-page">Back</a>
+  {% if 'your-questions' in previousPage %}
+    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
+      Back to your questions
+    </a>
+  {% elif (pageIndex-1) + '/check-question' in previousPage %}
+    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
+      Back to your questions
+    </a>
+  {% elif pageIndex + '/check-question' in previousPage %}
+    <a class="govuk-back-link" href="check-question" target="_parent">
+      Back
+    </a>
   {% else %}
-    <a class="govuk-back-link" href="../../clear-empty" target="_parent">Back to your questions</a>
+    <a class="govuk-back-link" href="javascript:window.history.back()">
+      Back
+    </a>
   {% endif %}
 {% endblock %}
 
@@ -117,14 +132,16 @@
         }) }}
 
         {{ govukButton({
-          text: "Save and continue",
+          text: "Continue",
           name: "action",
           value: "editPage"
         }) }}
 
-        {# <p class="govuk-body">
+        {% if ('your-questions' in previousPage) or ((pageIndex-1) + '/check-question' in previousPage) %}
+        <p class="govuk-body">
           <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
-        </p> #}
+        </p>
+        {% endif %}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/edit-answer-type.html
+++ b/app/views/form-designer/pages/edit-answer-type.html
@@ -13,15 +13,15 @@
 {% endset %}
 
 {% block beforeContent %}
-  {% if 'your-questions' in previousPage %}
+  {% if previousPage and ('your-questions' in previousPage) %}
     <a class="govuk-back-link" href="../../clear-empty" target="_parent">
       Back to your questions
     </a>
-  {% elif (pageIndex-1) + '/check-question' in previousPage %}
+  {% elif previousPage and ((pageIndex-1) + '/check-question' in previousPage) %}
     <a class="govuk-back-link" href="../../clear-empty" target="_parent">
       Back to your questions
     </a>
-  {% elif pageIndex + '/check-question' in previousPage %}
+  {% elif previousPage and (pageIndex + '/check-question' in previousPage) %}
     <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>

--- a/app/views/form-designer/pages/edit-select-question.html
+++ b/app/views/form-designer/pages/edit-select-question.html
@@ -20,19 +20,15 @@
 {% endblock %}
 
 {% block beforeContent %}
-{% if data.referer and ('edit-answer-type' in data.referer) %}
-    <a class="govuk-back-link" href="edit-answer-type">
-      Back
-    </a>
-  {% elif data.referer and ('settings' in data.referer) %}
-    <a class="govuk-back-link" href="edit-settings">
+  {% if 'check-question' in previousPage %}
+    <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>
   {% else %}
-  <a class="govuk-back-link" href="edit-answer-type">
-    Back
-  </a>
-{% endif%}
+    <a class="govuk-back-link" href="javascript:window.history.back()">
+      Back
+    </a>
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/pages/edit-select-question.html
+++ b/app/views/form-designer/pages/edit-select-question.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if 'check-question' in previousPage %}
+  {% if previousPage and ('check-question' in previousPage) %}
     <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>

--- a/app/views/form-designer/pages/edit-settings.html
+++ b/app/views/form-designer/pages/edit-settings.html
@@ -19,23 +19,15 @@
 {% endblock %}
 
 {% block beforeContent %}
-{% if data.referer and ('edit-answer-type' in data.referer) %}
-    <a class="govuk-back-link" href="edit-answer-type">
-      Back
-    </a>
-  {% elif data.referer and ('settings' in data.referer) %}
-    <a class="govuk-back-link" href="edit-settings">
-      Back
-    </a>
-  {% elif data.referer and ('edit-select-question' in data.referer) %}
-    <a class="govuk-back-link" href="edit-select-question">
+  {% if 'check-question' in previousPage %}
+    <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>
   {% else %}
-  <a class="govuk-back-link" href="edit-answer-type">
-    Back
-  </a>
-{% endif%}
+    <a class="govuk-back-link" href="javascript:window.history.back()">
+      Back
+    </a>
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/pages/edit-settings.html
+++ b/app/views/form-designer/pages/edit-settings.html
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if 'check-question' in previousPage %}
+  {% if previousPage and ('check-question' in previousPage) %}
     <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>

--- a/app/views/form-designer/pages/edit.html
+++ b/app/views/form-designer/pages/edit.html
@@ -58,7 +58,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if 'check-question' in previousPage %}
+  {% if previousPage and ('check-question' in previousPage) %}
     <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>
@@ -122,7 +122,7 @@
             name: "additional-guidance",
             fieldset: {
               legend: {
-                text: "Do you need to add more detail to help users answer the question?",
+                text: "Do you need to add guidance to help people answer the question?",
                 classes: "govuk-fieldset__legend--m"
               }
             },
@@ -141,7 +141,7 @@
                 checked: checked(namePrefix + "['additional-guidance']", "No")
               }
             ],
-            errorMessage: { text: errors['additionalGuidance'].text } if errors['additionalGuidance'].text
+            errorMessage: { text: errors['additional-guidance'].text } if errors['additional-guidance'].text
           }) }}
 
           <!-- Question settings -->

--- a/app/views/form-designer/pages/edit.html
+++ b/app/views/form-designer/pages/edit.html
@@ -6,55 +6,30 @@
 {% if pageData['type'] === 'personName' %}
   {% set questionHint = data.personNameQuestionHint %}
   {% set hintHint = data.personNameHintHint %}
-  {% set answerType = 'Person’s name' %}
-  {% set inputTypeTitle = data.personNameInputTypeTitle %}
-  {% if pageData['input'] === 'single-field' %}
-    {% set inputType = 'Full name in a single box' %}
-  {% elif pageData['input'] === 'multi-field' %}
-    {% set inputType = 'First and last names in separate boxes' %}
-  {% elif pageData['input'] === 'multi-field-plus' %}
-    {% set inputType = 'First, middle and last names in separate boxes' %}
-  {% endif %}
 {% elif pageData['type'] === 'companyName' %}
   {% set questionHint = data.companyNameQuestionHint %}
   {% set hintHint = data.companyNameHintHint %}
-  {% set answerType = 'Company or organisation’s name' %}
 {% elif pageData['type'] === 'email' %}
   {% set questionHint = data.emailQuestionHint %}
   {% set hintHint = data.emailHintHint %}
-  {% set answerType = 'Email address' %}
 {% elif pageData['type'] === 'phone' %}
   {% set questionHint = data.phoneQuestionHint %}
   {% set hintHint = data.phoneHintHint %}
-  {% set answerType = 'Phone number' %}
 {% elif pageData['type'] === 'national-insurance-number' %}
   {% set questionHint = data.ninoQuestionHint %}
   {% set hintHint = data.ninoHintHint %}
-  {% set answerType = 'National Insurance number' %}
 {% elif pageData['type'] === 'address' %}
   {% set questionHint = data.addressQuestionHint %}
   {% set hintHint = data.addressHintHint %}
-  {% set inputTypeTitle = data.addressInputTypeTitle %}
-  {% if ('uk-address' in pageData['input']) and ('international-address' in pageData['input']) %}
-    {% set inputType = 'UK and international addresses' %}
-  {% elif 'uk-address' in pageData['input'] %}
-    {% set inputType = 'UK addresses' %}
-  {% elif 'international-address' in pageData['input'] %}
-    {% set inputType = 'International addresses' %}
-  {% endif %}
 {% elif pageData['type'] === 'date' %}
-  {% set inputTypeTitle = data.dateOfBirthInputTypeTitle %}
   {% if pageData['input'] === 'yes' %}
     {% set questionHint = data.dobQuestionHint %}
     {% set hintHint = data.dobHintHint %}
-    {% set inputType = 'Yes' %}
   {% else %}
     {% set questionHint = data.dateQuestionHint %}
     {% set hintHint = data.dateHintHint %}
-    {% set inputType = 'No' %}
   {% endif %}
 {% elif pageData['type'] === 'select' %}
-  {% set answerType = 'Selection from a list' %}
   {% if pageData['oneOption'] %}
     {% set questionHint = data.selectionOneOptionQuestionHint %}
     {% set hintHint = data.selectionOneOptionHintHint %}
@@ -66,20 +41,16 @@
   {% set questionHint = data.numberQuestionHint %}
   {% set hintHint = data.numberHintHint %}
 {% elif pageData['type'] === 'text' %}
-  {% set inputTypeTitle = data.textLengthInputTypeTitle %}
   {% if pageData['input'] === 'single-line-input' %}
     {% set questionHint = data.textSingleLineQuestionHint %}
     {% set hintHint = data.textSingleLineHintHint %}
-    {% set inputType = 'A single line of text' %}
   {% else %}
     {% set questionHint = data.textMultipleLinesQuestionHint %}
     {% set hintHint = data.textMultipleLinesHintHint %}
-    {% set inputType = 'More than a single line of text' %}
   {% endif %}
 {% else %}
   {% set questionHint = 'Ask a question the way you would in person. For example ‘What is your address?’' %}
   {% set hintHint = "Use hint text to help people answer the question. For example, to explain the format the answer should be in, or where to find the information you’ve asked for." %}
-  {% set inputTypeTitle = 'Input type' %}
 {% endif %}
 
 {% block pageTitle %}
@@ -87,39 +58,28 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if data.referer and ('edit-answer-type' in data.referer) %}
-    <a class="govuk-back-link" href="edit-answer-type">
-      Back
-    </a>
-  {% elif data.referer and ('settings' in data.referer) %}
-    <a class="govuk-back-link" href="edit-settings">
+  {% if 'check-question' in previousPage %}
+    <a class="govuk-back-link" href="check-question" target="_parent">
       Back
     </a>
   {% else %}
-    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
-      Back to your questions
+    <a class="govuk-back-link" href="javascript:window.history.back()">
+      Back
     </a>
   {% endif %}
 {% endblock %}
 
 {% block content %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-        {% if successMessage %}
-        {{ govukNotificationBanner({
-          type: 'success',
-          text: successMessage
-        }) }}
-        {% endif %}
-
-        <form id="form" class="form" method="post" novalidate>
+      <form id="form" class="form" method="post" novalidate>
 
           {% if containsErrors %}
-          {{ govukErrorSummary({
-            titleText: "There is a problem",
-            errorList: errorList
-          }) }}
+            {{ govukErrorSummary({
+              titleText: "There is a problem",
+              errorList: errorList
+            }) }}
           {% endif %}
 
           <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
@@ -139,11 +99,11 @@
             id: "long-title",
             name: "long-title",
             value: pageData['long-title'],
-            errorMessage: { text: errors['long-title'].text } if errors['long-title'].text
+            errorMessage: { text: errors['long-title'].text } if errors['long-title'].text 
           }) }}
 
           <!-- Hint text input -->
-          {{ govukInput({
+          {{ govukTextarea({
             label: {
               text: "Hint text (optional)",
               classes: "govuk-label--m"
@@ -156,166 +116,69 @@
             value: pageData['hint-text']
           }) }}
 
-           {% if pageData['type'] != 'select' %}
-
-          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-          {{ govukCheckboxes({
-            idPrefix: "questionOptional",
-            name: "questionOptional",
+          <!-- Additional guidance -->
+          {{ govukRadios({
+            classes: "govuk-radios--inline",
+            name: "additional-guidance",
             fieldset: {
               legend: {
-                text: "Question settings",
+                text: "Do you need to add more detail to help users answer the question?",
                 classes: "govuk-fieldset__legend--m"
               }
             },
+            hint: {
+              text: "Only add guidance if you need to give a longer explanation of how to answer the question, or to format your content. For example, you can use paragraphs, links or lists."
+            },
             items: [
               {
-                value: "questionOptional",
-                text: "Make this question optional so people can skip it",
-                hint: {
-                  text: "‘(optional)’ will be added to the end of the question text"
-                },
-                checked: checked(namePrefix + "['questionOptional']", "questionOptional")
+                value: "Yes",
+                text: "Yes",
+                checked: checked(namePrefix + "['additional-guidance']", "Yes")
+              },
+              {
+                value: "No",
+                text: "No",
+                checked: checked(namePrefix + "['additional-guidance']", "No")
               }
-            ]
+            ],
+            errorMessage: { text: errors['additionalGuidance'].text } if errors['additionalGuidance'].text
           }) }}
 
-          <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+          <!-- Question settings -->
+          {% if pageData['type'] != 'select' %}
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-          {% endif %}
-
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Answer type
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{answerType}}
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-answer-type">
-                  Change <span class="govuk-visually-hidden">answer type {{answerType}}<span>
-                </a>
-              </dd>
-            </div>
-            {% if pageData['input'] %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                {{inputTypeTitle}}
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{inputType}}
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#input">
-                  Change <span class="govuk-visually-hidden">input type {{inputType}}<span>
-                </a>
-              </dd>
-            </div>
-            {% endif %}
-            {% if pageData['title'] %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Title needed
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{pageData['title']|capitalize}}
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#title">
-                  Change <span class="govuk-visually-hidden">title needed {{pageData['title']|capitalize}}<span>
-                </a>
-              </dd>
-            </div>
-            {% endif %}
-            {% if pageData['item-list'] %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Options
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {% if (pageData['item-list']|length|int >= 1) %}
-                  {% for item in pageData['item-list'] %}{{item}}{% if not loop.last %}, {% endif %}{% endfor %}
-                {% else %}
-                  No options added
-                {% endif %}
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#option-0">
-                  Change <span class="govuk-visually-hidden">options<span>
-                </a>
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Only select one option
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') else 'No'}}
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#oneOption">
-                  Change <span class="govuk-visually-hidden">only select one option<span>
-                </a>
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Include 'none of the above' option
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') else 'No'}}
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#noneOption">
-                  Change <span class="govuk-visually-hidden">include 'none of the above' option<span>
-                </a>
-              </dd>
-            </div>
-            {% endif %}
-          </dl>
-
-          <div class="govuk-button-group">
-            {% if pageId >= data['highestPageId'] %}
-
-              {{ govukButton({
-                text: "Save and add next question",
-                name: "action",
-                value: "createNextPage"
-              }) }}
-
-            {% else %}
-
-              {{ govukButton({
-                text: "Save and edit next question",
-                name: "action",
-                value: "editNextPage"
-              }) }}
-
-            {% endif %}
-
-            {{ govukButton({
-              text:  "Save question",
-              name: "action",
-              value: "update",
-              classes: "govuk-button--secondary"
+            {{ govukCheckboxes({
+              idPrefix: "questionOptional",
+              name: "questionOptional",
+              fieldset: {
+                legend: {
+                  text: "Question settings",
+                  classes: "govuk-fieldset__legend--m"
+                }
+              },
+              items: [
+                {
+                  value: "questionOptional",
+                  text: "Make this question optional so people can skip it",
+                  hint: {
+                    text: "‘(optional)’ will be added to the end of the question text"
+                  },
+                  checked: checked(namePrefix + "['questionOptional']", "questionOptional")
+                }
+              ]
             }) }}
-          </div>
+          {% endif %}
 
-          {% if editingExistingQuestion %}
           {{ govukButton({
-            text: "Delete question",
-            classes: "govuk-button--warning",
+            text: "Continue",
             name: "action",
-            value: "deletePage"
+            value: "editPage"
           }) }}
 
-          {# Move go to your questions link only if a question is saved #}
-          <p class="govuk-body">
+          {# <p class="govuk-body">
             <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
-          </p>
-          {% endif %}
+          </p> #}
 
       </form>
     </div>

--- a/app/views/form-designer/preview/page.html
+++ b/app/views/form-designer/preview/page.html
@@ -1,10 +1,15 @@
 {% extends "layout-govuk-form-preview.html" %}
 {% set mainClasses = "main--draft govuk-main-wrapper--auto-spacing" %}
 
+{% if pageData['additional-guidance'] == 'Yes' %}
+  {% set pageHeading = pageData['page-name'] or 'Guidance text' %}
+{% endif %}
+
 {% set pageTitle = pageData['long-title'] or 'Question text' %}
 {% if pageData['questionOptional'] %}
-{% set pageTitle = pageTitle + ' (optional)' %}
+  {% set pageTitle = pageTitle + ' (optional)' %}
 {% endif %}
+
 
 {% block beforeContent %}
   {% set prevPageId = pageId | int - 1 %}
@@ -16,7 +21,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {{ pageTitle }} - Preview - {{ data['formTitle'] }} - GOV.UK
+  {% if pageHeading %}{{ pageHeading }}{% else %}{{ pageTitle }}{% endif %} - Preview - {{ data['formTitle'] }} - GOV.UK
 {% endblock %}
 
 {% block content %}
@@ -27,6 +32,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form class="form" method="post" novalidate>
+
+        {% if pageData['additional-guidance'] == 'Yes' %}
+        <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+        {% markdown %}{{ markdownContent }}{% endmarkdown %}
+        {% endif %}
 
         {#
 
@@ -39,8 +49,8 @@
         {# The heading doubles up as the label #}
         {% set label = {
           text: pageTitle,
-          classes: "govuk-label--l",
-          isPageHeading: true
+          classes: "govuk-label--l" if pageData['additional-guidance'] != 'Yes' else "govuk-label--m",
+          isPageHeading: true if pageData['additional-guidance'] != 'Yes'
         }%}
 
         {# Full name in a single field #}
@@ -50,8 +60,8 @@
             {% call govukFieldset({
               legend: {
                 text: pageTitle,
-                classes: "govuk-fieldset__legend--l",
-                isPageHeading: true
+                classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+                isPageHeading: true if pageData['additional-guidance'] != 'Yes'
               }
             }) %}
 
@@ -114,8 +124,8 @@
             {% call govukFieldset({
               legend: {
                 text: pageTitle,
-                classes: "govuk-fieldset__legend--l",
-                isPageHeading: true
+                classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+                isPageHeading: true if pageData['additional-guidance'] != 'Yes'
               }
             }) %}
 
@@ -218,8 +228,8 @@
           {% call govukFieldset({
             legend: {
               text: pageTitle,
-              classes: "govuk-fieldset__legend--l",
-              isPageHeading: true
+              classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+              isPageHeading: true if pageData['additional-guidance'] != 'Yes'
             }
           }) %}
 

--- a/app/views/form-designer/your-questions.html
+++ b/app/views/form-designer/your-questions.html
@@ -67,8 +67,8 @@
           classes: "govuk-!-margin-bottom-7"
         }) }}
         {% if data.pages.length %}
-        <a class="govuk-link" href="/form-designer/preview/0" target="_blank" rel="noopener noreferrer">
-          Preview this form in a new tab
+        <a class="govuk-link" href="/form-designer/preview/0" rel="noopener noreferrer">
+          Preview this form
         </a>
         {% endif %}
       </div>
@@ -94,6 +94,7 @@
           {{loop.index}}
         </dt>
         <dd class="govuk-summary-list__value">
+          {% if page['page-name'] %}{{page['page-name']}}<br>{% endif %}
           <!--Q{{page["pageIndex"] | int + 1}}.-->
           {{questionTitle}}
         </dd>
@@ -116,7 +117,7 @@
               }) }}
               {% endif %}
               <div>
-                <a class="govuk-link govuk-link--no-visited-state" href="pages/{{ page.pageIndex | int }}/edit">
+                <a class="govuk-link govuk-link--no-visited-state" href="pages/{{ page.pageIndex | int }}/check-question">
                   Edit<span class="govuk-visually-hidden"> {{questionTitle}}</span>
                 </a>
               </div>

--- a/app/views/form-designer/your-questions.html
+++ b/app/views/form-designer/your-questions.html
@@ -94,9 +94,10 @@
           {{loop.index}}
         </dt>
         <dd class="govuk-summary-list__value">
-          {% if page['page-name'] %}{{page['page-name']}}<br>{% endif %}
           <!--Q{{page["pageIndex"] | int + 1}}.-->
           {{questionTitle}}
+          {#{% if page['page-name'] %}<br>Guidance added{% endif %}#}
+          {#{% if page['page-name'] %}<br>Page heading: {{page['page-name']}}{% endif %}#}
         </dd>
         <dd class="govuk-summary-list__actions">
           <div class="govuk-button-group form-action-group govuk-!-margin-bottom-0">

--- a/app/views/layout-govuk-form-preview.html
+++ b/app/views/layout-govuk-form-preview.html
@@ -4,8 +4,15 @@
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: data['formTitle'],
-    serviceUrl: "/",
-    containerClasses: "govuk-width-container"
+    serviceUrl: "../your-questions",
+    containerClasses: "govuk-width-container",
+    navigationClasses: "govuk-header__navigation--end govuk-!-display-block",
+    navigation: [
+      {
+        href: "../your-questions",
+        text: "Your questions"
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "dependencies": {
         "@govuk-prototype-kit/step-by-step": "^2.1.0",
         "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.1",
-        "govuk-frontend": "^4.5.0",
+        "govuk-frontend": "^4.7.0",
+        "govuk-markdown": "^0.4.0",
         "govuk-prototype-kit": "^13.4.0",
         "jquery": "^3.6.4",
         "marked": "^4.2.12",
@@ -62,11 +63,34 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/govuk-markdown": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-markdown/-/govuk-markdown-0.4.0.tgz",
+      "integrity": "sha512-DSEZ02kRVeAbOvNBUubEfPZxMRIjLfc26gfOcarDX7GXz6Ij9lBddhBOBylJ0IQaNGTQANgj8GF6radrYN66nQ==",
+      "dependencies": {
+        "highlight.js": "^11.5.0",
+        "marked": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/govuk-markdown/node_modules/marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/govuk-prototype-kit": {
@@ -3953,6 +3977,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jquery": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
@@ -4114,9 +4146,25 @@
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
+    },
+    "govuk-markdown": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-markdown/-/govuk-markdown-0.4.0.tgz",
+      "integrity": "sha512-DSEZ02kRVeAbOvNBUubEfPZxMRIjLfc26gfOcarDX7GXz6Ij9lBddhBOBylJ0IQaNGTQANgj8GF6radrYN66nQ==",
+      "requires": {
+        "highlight.js": "^11.5.0",
+        "marked": "^5.0.0"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+          "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg=="
+        }
+      }
     },
     "govuk-prototype-kit": {
       "version": "13.4.0",
@@ -6976,6 +7024,11 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
+    },
+    "highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg=="
     },
     "jquery": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "@govuk-prototype-kit/step-by-step": "^2.1.0",
     "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.1",
-    "govuk-frontend": "^4.5.0",
+    "govuk-frontend": "^4.7.0",
+    "govuk-markdown": "^0.4.0",
     "govuk-prototype-kit": "^13.4.0",
     "jquery": "^3.6.4",
     "marked": "^4.2.12",


### PR DESCRIPTION
Some minor updates to align with where build is.

- Added new detailed guidance screen (no way to do a quick preview)
- Also displays and restructures the runner equivalent to match [design system pattern](https://design-system.service.gov.uk/patterns/question-pages/#asking-complex-questions-without-using-hint-text)
- Added new check your question (CYA) screen to question creation journey

Needed to update/add `marked` plugin and overwrite the renderer for this as per instructions for [govuk-markdown plugin](https://github.com/x-govuk/govuk-markdown). 
- the renderer is set in `routes.js` 
```
marked.setOptions({
  renderer: new GovukHTMLRenderer()
})
```

Updated back buttons for question creation journey to fix some bugs and match the new journey better, but means using `javascript:window.history.back()` for the `href` - not sure if it matters as this is only a prototype.