### PR TITLE
Fix nunjucks-markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "govuk-prototype-kit",
       "dependencies": {
         "@govuk-prototype-kit/step-by-step": "^2.1.0",
-        "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.1",
+        "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
         "govuk-frontend": "^4.7.0",
         "govuk-markdown": "^0.4.0",
         "govuk-prototype-kit": "^13.4.0",
@@ -24,7 +24,7 @@
     },
     "node_modules/@lfdebrux/nunjucks-markdown": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin.git#aaf25848945087b3c5807719b87d34c9a51b1eb7",
+      "resolved": "git+ssh://git@github.com/lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin.git#df9902a173031e5272466adfb129bbdb0acf8e84",
       "license": "MIT",
       "peerDependencies": {
         "govuk-prototype-kit": "^13.0.0"
@@ -3729,8 +3729,8 @@
       "integrity": "sha512-GSpKqBKetFxsLpVBjl74PJnkK81PGip8PPRspukaIdS4/oLLUFEs7IRDnjc/mrlGavPbfHWHIuVWH+Usl5A9sA=="
     },
     "@lfdebrux/nunjucks-markdown": {
-      "version": "git+ssh://git@github.com/lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin.git#aaf25848945087b3c5807719b87d34c9a51b1eb7",
-      "from": "@lfdebrux/nunjucks-markdown@github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.1",
+      "version": "git+ssh://git@github.com/lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin.git#df9902a173031e5272466adfb129bbdb0acf8e84",
+      "from": "@lfdebrux/nunjucks-markdown@github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
       "requires": {}
     },
     "@socket.io/component-emitter": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "name": "govuk-prototype-kit",
   "dependencies": {
     "@govuk-prototype-kit/step-by-step": "^2.1.0",
-    "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.1",
+    "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
     "govuk-frontend": "^4.7.0",
     "govuk-markdown": "^0.4.0",
     "govuk-prototype-kit": "^13.4.0",


### PR DESCRIPTION
We've been getting the following error when running our prototype:

```
Error: Cannot find module 'govuk-prototype-kit/node_modules/nunjucks'
```

This PR bumps [@lfdebrux/nunjucks-markdown](https://github.com/lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin) from 0.0.1 to 0.0.3.

This fixes the nunjucks-markdown tags; version 13.5.0 of govuk-prototype-kit changed the way that package is released, which in turn broke assumptions in @lfdebrux/nunjucks-markdown. Version 0.0.3 of @lfdebrux/nunjucks-markdown has been tested with the latest version of govuk-prototype-kit and works again.