### PR TITLE
204 2023 12 06 previewing a question during creation

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,64 +9,51 @@
 @import "patterns/moj-messages";
 @import "patterns/govuk-publishing-document-list";
 
-/*  Remove sticky pane
-    Allow content to be left aligned
-.preview-pane-wrapper {
-  position: sticky;
-  top: 110px;
-  text-align: center;
-}
-*/
 
-.preview-pane {
+/* PREVIEW QUESTION - EDIT JOURNEY
+================================== */
+.app-preview-pane-wrapper {
   overflow: hidden;
-  height: 570px;
   width: calc(100% - 4px);
   border: 2px solid black;
   border-top: none;
   margin-bottom: govuk-spacing(2);
 }
 
-.update-button,
-.update-button:hover {
-  color: $govuk-link-colour;
-  text-decoration: underline;
-  @extend %govuk-link;
-  background: none;
-  box-shadow: none;
+.app-preview-pane {
+  padding: 30px 15px;
+}
+@media (min-width: 40.0625em) {
+  .app-preview-pane {
+    padding-left: 30px;
+    padding-right: 30px;
+  }
+}
+@media (max-width: 640px) {
+  .app-preview-pane {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
-.update-button:hover {
-  text-decoration-thickness: 2px;
-  color: $govuk-link-hover-colour;
+.app-preview-header-container {
+  padding-left: 15px;
+  padding-right: 15px;
 }
-
-// Header of the preview pane
-.preview-header {
-  height: 35px;
-  background-color: govuk-colour("black");
-
-  background-image: url(/public/images/mini-logo.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position-x: -15px;
-  border: 2px solid black;
-  border-bottom: 5px solid $govuk-brand-colour;
-
-  p {
-    color: govuk-colour("white");
-    padding: 6px govuk-spacing(3);
-    margin-bottom: 0;
-    float: right;
-    a {
-      color: govuk-colour("white");
-      font-size: 14px;
-    }
+@media (min-width: 40.0625em) {
+  .app-preview-header-container {
+    padding-left: 30px;
+    padding-right: 30px;
+  }
+}
+@media (max-width: 640px) {
+  .app-preview-header-container {
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
 // Prose scope (stolen from the kit docs)
-
 .app-prose-scope {
   h1 {
     @extend %govuk-heading-l;
@@ -122,6 +109,7 @@
     background-color: govuk-colour("light-grey", $legacy: "grey-4");
     padding: 0 govuk-spacing(1);
   }
+
 
   // TODO: Blockquotes are likely the most semantic element to be using, update to use the inset component directly.
   blockquote {

--- a/app/routes.js
+++ b/app/routes.js
@@ -552,7 +552,9 @@ router.get('/form-designer/preview/:pageId(\\d+)', function (req, res) {
   var pageData = req.session.data.pages[pageIndex]
   const isLastQuestionPage = pageIndex === (req.session.data.pages.length - 1)
 
-  var markdownContent = pageData['additional-guidance-text']
+  if (pageData) {
+    var markdownContent = pageData['additional-guidance-text']
+  }
 
   res.render('form-designer/preview/page', {
     pageId: pageId,

--- a/app/views/form-designer/name-your-form.html
+++ b/app/views/form-designer/name-your-form.html
@@ -7,7 +7,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a class="govuk-back-link" href="your-form">Back</a>
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/form-designer/pages/_routes.js
+++ b/app/views/form-designer/pages/_routes.js
@@ -1,0 +1,743 @@
+const govukPrototypeKit = require('govuk-prototype-kit')
+const router = govukPrototypeKit.requests.setupRouter()
+
+/* CREATING A NEW QUESTION
+========================== */
+
+// Create a new page or question route - button journeys
+router.get('/form-designer/pages/new', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  var action = req.session.data.action
+  req.session.data.action = undefined
+
+  // remove empty pageData if there is only one object (pageIndex) in array
+  const pages = req.session.data.pages.filter(element => {
+    if (Object.keys(element).length > 1) {
+      return true
+    }
+    return false
+  })
+  // Save the pages
+  req.session.data.pages = pages
+
+  // reset highestPageId to number of pages
+  req.session.data.highestPageId = parseInt(pages.length - 1)
+
+  if (action === 'addRoute') {
+    // add a new question route
+    res.redirect(`/form-designer/question-routes/new-condition`)
+  } else {
+
+    var nextPageId = req.session.data.pages.length
+  
+    if (!pageData) {
+      req.session.data.pages.push({
+        'pageIndex': nextPageId
+      })
+    }
+    // add a new question
+    res.redirect(`/form-designer/pages/${nextPageId}/edit-answer-type`)
+  }
+})
+
+
+/* ANSWER TYPE
+============== */
+
+// Edit a user-created answer type
+router.get('/form-designer/pages/:pageId(\\d+)/edit-answer-type', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  // get the previous page URL
+  var previousPage = req.session.data.referer
+  // now we can set the back link data (text and url)
+  var tempArray = backLink(previousPage, pageIndex, pageData)
+
+  return res.render('form-designer/pages/edit-answer-type', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData,
+    previousPageLink: tempArray[0].previousPageLink,
+    previousPageText: tempArray[0].previousPageText
+  })
+})
+
+// Route used to find correct next step - answer type > settings page || edit question page
+router.post('/form-designer/pages/:pageId(\\d+)/edit-answer-type', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  var type = req.session.data.type
+  req.session.data.type = undefined
+
+  var errors = {};
+
+  // if no selection made, then throw an error
+  if (!type || !type.length) {
+    errors['type'] = {
+      text: 'Select the type of answer you need',
+      href: "#type"
+    }
+  } else {
+    pageData['type'] = type
+  }
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  // If there are errors on the page, redisplay it with the errors
+  if(containsErrors) {
+    return res.render('form-designer/pages/edit-answer-type', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      errors,
+      errorList,
+      containsErrors
+    })
+  } else {
+    const nextPageId = req.session.data.pages.length
+
+    if (!pageData) {
+      req.session.data.pages.push({
+        'pageIndex': nextPageId
+      })
+    }
+    if (type === 'personName') {
+      // person's name route
+      return res.redirect('edit-settings')
+    } else if (type === 'address') {
+      // address route
+      return res.redirect('edit-settings')
+    } else if (type === 'date') {
+      // date route
+      return res.redirect('edit-settings')
+    } else if (type === 'select') {
+      // what's your question route
+      return res.redirect('edit-select-question')
+    } else if (type === 'text') {
+      // text route
+      return res.redirect('edit-settings')
+    } else {
+      return res.redirect('edit')
+    }
+  }
+})
+
+
+/* START selection from a list of options */
+// Edit a user-created answer type settings
+router.get('/form-designer/pages/:pageId(\\d+)/edit-select-question', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  // get the previous page URL
+  var previousPage = req.session.data.referer
+  // now we can set the back link data (text and url)
+  var tempArray = backLink(previousPage, pageIndex, pageData)
+
+  return res.render('form-designer/pages/edit-select-question', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData,
+    previousPageText: tempArray[0].previousPageText,
+    previousPageLink: tempArray[0].previousPageLink
+  })
+})
+
+// Route to what is your question page for select from list answer type
+router.post('/form-designer/pages/:pageId(\\d+)/edit-select-question', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  const type = req.session.data.type
+  req.session.data.type = undefined
+
+  const complete = req.session.data.isDeclarationComplete
+
+  const errors = {};
+  const title = req.session.data['long-title']
+
+  // if no question text given, then throw an error
+  if (!title || !title.length) {
+    errors['long-title'] = {
+      text: 'Enter your question',
+      href: "#long-title"
+    }
+  // otherwise add question text to pageData
+  } else {
+    pageData['long-title'] = req.session.data['long-title']
+  }
+  req.session.data['long-title'] = undefined
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  // If there are errors on the page, redisplay it with the errors
+  if(containsErrors) {
+    return res.render('form-designer/pages/edit-select-question', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      errors,
+      errorList,
+      containsErrors
+    })
+  } else {
+    const nextPageId = req.session.data.pages.length
+    res.redirect('edit-settings')
+  }
+})
+/* END of selection from a list of options */
+
+
+// Edit a user-created answer type settings
+router.get('/form-designer/pages/:pageId(\\d+)/edit-settings', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  // get the previous page URL
+  var previousPage = req.session.data.referer
+  // now we can set the back link data (text and url)
+  var tempArray = backLink(previousPage, pageIndex, pageData)
+
+  // Overwrite back link IF we are just adding/removing options from ‘selection from a list’
+  if (req.session.data.tempSelectStatus === 'No') {
+    tempArray[0].previousPageLink = `edit-select-question`
+    tempArray[0].previousPageText = 'Back to what’s your question'
+  }
+  req.session.data.tempSelectStatus = undefined
+
+  return res.render('form-designer/pages/edit-settings', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData,
+    previousPageText: tempArray[0].previousPageText,
+    previousPageLink: tempArray[0].previousPageLink
+  })
+})
+
+// Route used to find correct next step - settings page > edit question page
+router.post('/form-designer/pages/:pageId(\\d+)/edit-settings', function (req, res) {
+  var action = req.session.data.action
+  // clear the action so it doesn't change the next page load
+  req.session.data.action = undefined
+
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  // Get basic errors
+  const errors = {};
+
+  // if select option from list and no, or 1, input is given throw error, else add input to pageData
+  var itemList = req.session.data['item-list']
+  var listSettings = req.session.data['listSettings']
+
+  req.session.data['item-list'] = undefined
+  req.session.data['listSettings'] = undefined
+
+  if (pageData['type'] === 'select') {
+    const lastItem = itemList.length - 1
+    // check for empty values
+    const tempList = itemList.filter(element => {
+      if (Object.keys(element).length !== 0) {
+        return true
+      }
+      return false
+    })
+    itemList = tempList
+    if (!itemList.length) {
+      errors['item-list'] = {
+        text: 'Enter at least 2 options',
+        href: "#option-0"
+      }
+    } else if (itemList.length < 2) {
+      errors['item-list'] = {
+        text: 'Enter at least 2 options',
+        href: "#option-0"
+      }
+    }
+    pageData['item-list'] = itemList
+    pageData['listSettings'] = listSettings
+  } else if (!req.session.data.input || !req.session.data.input.length) {
+  // if no input is selected throw error, else add input to pageData
+    if (pageData['type'] === 'personName') {
+      errors['input'] = {
+        text: 'Select how you need to collect the name',
+        href: "#input"
+      }
+    } else if (pageData['type'] === 'address') {
+      errors['input'] = {
+        text: 'Select the kind of addresses you expect to receive',
+        href: "#input"
+      }
+    } else if (pageData['type'] === 'date') {
+      errors['input'] = {
+        text: 'Select yes if you’re asking for a date of birth',
+        href: "#input"
+      }
+    } else if (pageData['type'] === 'text') {
+      errors['input'] = {
+        text: 'Select how much text people will need to provide',
+        href: "#input"
+      }
+    } else {
+      errors['input'] = {
+        text: 'Select an answer',
+        href: "#input"
+      }
+    }
+  } else {
+    pageData['input'] = req.session.data.input
+  }
+  req.session.data.input = undefined
+
+  // if asking for person’s name and title answer not selected throw error, else add input to pageData
+  if (pageData['type'] === 'personName') {
+    if (!req.session.data.title || !req.session.data.title.length) {
+      errors['title'] = {
+        text: 'Select yes if you need a title',
+        href: "#title"
+      }
+    } else {
+      pageData['title'] = req.session.data.title
+    }
+  }
+  req.session.data.title = undefined
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  // If there are errors on the page, redisplay it with the errors
+  if(containsErrors) {
+    return res.render('form-designer/pages/edit-settings', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      errors,
+      errorList,
+      containsErrors
+    })
+  } else if (action === 'addAnother') {
+    const lastItem = itemList.length - 1
+    if (itemList[lastItem]) {
+      itemList.push("")
+    }
+    req.session.data.tempSelectStatus = 'No'
+    return res.redirect('edit-settings')
+  } else if (action.includes('removeOption')) {
+    // get item position to remove via remove button value
+    var remove = action.split("-")
+    var itemToRemove = remove.pop()
+    // only splice array when item is found
+    if (itemToRemove > -1) {
+      // if options are now less than 2 add an empty option input
+      if (itemList.length <= 2) {
+        itemList.push("")
+      }
+      // 2nd parameter means remove one item only
+      itemList.splice(itemToRemove, 1)
+    }
+    req.session.data.tempSelectStatus = 'No'
+    return res.redirect('edit-settings')
+  } else {
+    req.session.data.tempSelectStatus = 'Yes'
+    return res.redirect('edit')
+  }
+})
+
+/* START editing question text and hint text */
+// Edit a user-created question
+router.get('/form-designer/pages/:pageId(\\d+)/edit', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  // get the previous page URL
+  var previousPage = req.session.data.referer
+  // now we can set the back link data (text and url)
+  var tempArray = backLink(previousPage, pageIndex, pageData)
+
+  return res.render('form-designer/pages/edit', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData,
+    previousPageText: tempArray[0].previousPageText,
+    previousPageLink: tempArray[0].previousPageLink
+  })
+})
+
+// Route used to find correct next step - edit question page > answer type
+router.post('/form-designer/pages/:pageId(\\d+)/edit', function (req, res) {
+  var action = req.session.data.action
+  // clear the action so it doesn't change the next page load
+  req.session.data.action = undefined
+
+  var additionalGuidance = req.session.data['additional-guidance']
+
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  const errors = {};
+
+  if (!pageData['long-title']) {
+    const title = req.session.data['long-title']
+
+    // if no question text given, then throw an error
+    if (!title || !title.length) {
+      errors['long-title'] = {
+        text: 'Enter a question',
+        href: "#long-title"
+      }
+    // otherwise add question text to pageData
+    } else {
+      pageData['long-title'] = req.session.data['long-title']
+    }
+    req.session.data['long-title'] = undefined
+  }
+
+  // if hint text is added, add it to pageData
+  if (req.session.data['hint-text']) {
+    pageData['hint-text'] = req.session.data['hint-text']
+  }
+  req.session.data['hint-text'] = undefined
+
+  // if no additional guidance answer, then throw an error
+  if (!additionalGuidance || !additionalGuidance.length) {
+    errors['additional-guidance'] = {
+      text: 'Select ‘Yes’ to add guidance',
+      href: "#additional-guidance"
+    }
+  // otherwise add question text to pageData
+  } else {
+    pageData['additional-guidance'] = req.session.data['additional-guidance']
+  }
+  req.session.data['additional-guidance'] = undefined
+
+  // if question is made optional, add it to pageData
+  if (req.session.data['questionOptional']) {
+    pageData['questionOptional'] = req.session.data['questionOptional']
+  }
+  req.session.data['questionOptional'] = undefined
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  // If there are errors on the page, redisplay it with the errors
+  if(containsErrors) {
+    return res.render('form-designer/pages/edit', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      errors,
+      errorList,
+      containsErrors
+    })
+  } else if (additionalGuidance == 'Yes') {
+    return res.redirect(`additional-guidance`)
+  } else {
+    return res.redirect(`check-question`)
+  }
+})
+/* END editing question text and hint text */
+
+
+// Add additional guidance
+router.get('/form-designer/pages/:pageId(\\d+)/additional-guidance', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  var successMessage = req.session.data.successMessage
+  req.session.data.successMessage = undefined
+
+  // get the previous page URL
+  var previousPage = req.session.data.referer
+  // now we can set the back link data (text and url)
+  var tempArray = backLink(previousPage, pageIndex, pageData)
+
+  return res.render('form-designer/pages/additional-guidance', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData,
+    successMessage,
+    previousPageText: tempArray[0].previousPageText,
+    previousPageLink: tempArray[0].previousPageLink
+  })
+})
+
+// Add additional guidance text route
+router.post('/form-designer/pages/:pageId(\\d+)/additional-guidance', function (req, res) {
+  var action = req.session.data.action
+  // clear the action so it doesn't change the next page load
+  req.session.data.action = undefined
+
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  const errors = {};
+  const pageHeading = req.session.data['page-name']
+  const guidanceText = req.session.data['additional-guidance-text']
+
+  // if no page heading given, then throw an error
+  if (!pageHeading || !pageHeading.length) {
+    errors['page-name'] = {
+      text: 'Enter a page heading',
+      href: "#page-name"
+    }
+  // otherwise add page heading to pageData
+  } else {
+    pageData['page-name'] = req.session.data['page-name']
+  }
+  req.session.data['page-name'] = undefined
+
+  // if no guidance text given, then throw an error
+  if (!guidanceText || !guidanceText.length) {
+    errors['additional-guidance-text'] = {
+      text: 'Enter guidance text',
+      href: "#edit-guidance-text"
+    }
+  // otherwise add guidance text to pageData
+  } else {
+    pageData['additional-guidance-text'] = req.session.data['additional-guidance-text']
+  }
+  req.session.data['additional-guidance-text'] = undefined
+
+  // content to display in notification banners
+  var previewing = 'Preview your guidance text'
+
+  // Convert the errors into a list, so we can use it in the template
+  const errorList = Object.values(errors)
+  // If there are no errors, redirect the user to the next page
+  // otherwise, show the page again with the errors set
+  const containsErrors = errorList.length > 0
+  // If there are errors on the page, redisplay it with the errors
+  if(containsErrors) {
+    return res.render('form-designer/pages/additional-guidance', {
+      pageId: pageId,
+      pageIndex: pageIndex,
+      pageData: pageData,
+      errors,
+      errorList,
+      containsErrors
+    })
+  } else if(action == 'previewGuidance') {
+    req.session.data.successMessage = previewing
+    res.redirect('additional-guidance#preview-guidance-text')
+  } else {
+    res.redirect('check-question')
+  }
+})
+
+
+/* Saving a question 
+==================== */
+
+router.use('/form-designer/pages/:pageId(\\d+)/check-question', function (req, res, next) {
+
+  // remove empty pageData if there is only one object (pageIndex) in array
+  const pages = req.session.data.pages.filter(element => {
+    if (Object.keys(element).length > 1) {
+      return true
+    }
+    return false
+  })
+  // Save the pages
+  req.session.data.pages = pages
+
+  // reset highestPageId to number of pages
+  req.session.data.highestPageId = parseInt(pages.length - 1)
+
+  next();
+})
+
+// Check your questions - CYA
+router.get('/form-designer/pages/:pageId(\\d+)/check-question', function (req, res) {
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  var editNextPageId = pageId + 1
+  var nextActionText = 'Add a new question'
+  var nextActionURL = `../new`
+
+  if (pageId < req.session.data.pages.length - 1) {
+    nextActionText = 'Edit next question'
+    nextActionURL = `../` + editNextPageId + `/check-question` 
+  }
+
+  var editingExistingQuestion = 'No'
+  if (pageData && pageData['questionSaved']) {
+    editingExistingQuestion = pageData['questionSaved']
+  }
+
+  var successMessage = req.session.data.successMessage
+  req.session.data.successMessage = undefined
+
+  console.log(successMessage)
+
+  // get the previous page URL
+  var previousPage = req.session.data.referer
+  // now we can set the back link data (text and url)
+  var tempArray = backLink(previousPage, pageIndex, pageData)
+
+  return res.render('form-designer/pages/check-question', {
+    pageId: pageId,
+    pageIndex: pageIndex,
+    pageData: pageData,
+    successMessage,
+    nextActionText,
+    nextActionURL,
+    editingExistingQuestion,
+    previousPageText: tempArray[0].previousPageText,
+    previousPageLink: tempArray[0].previousPageLink
+  })
+})
+
+// Route used to find correct next step - edit question page > answer type
+router.post('/form-designer/pages/:pageId(\\d+)/check-question', function (req, res) {
+  var action = req.session.data.action
+  // clear the action so it doesn't change the next page load
+  req.session.data.action = undefined
+
+  var pageId = parseInt(req.params.pageId, 10)
+  var pageIndex = pageId
+  var pageData = req.session.data.pages[pageIndex]
+
+  if (pageData['questionSaved']) {
+    var existingQuestion = true
+  }
+
+  // No need to validate if the user wants to delete this page anyway
+  if (action === 'deletePage') {
+    return res.redirect(`delete`)
+  }
+
+  // content to display in notification banners
+  var savedNewQuestion = 'Question ' + (parseInt(pageId) + 1) + ' has been saved'
+  var saved = 'Your changes have been saved'
+
+  if (existingQuestion) {
+    req.session.data.successMessage = saved
+  } else {
+    req.session.data.successMessage = savedNewQuestion
+    if (pageData) {
+      pageData['questionSaved'] = req.session.data.questionSaved
+      req.session.data.questionSaved = undefined
+    }
+  }
+  return res.redirect(req.path)
+})
+
+
+
+/* Function to get a page back link
+=================================== */
+function backLink(previousPage, pageIndex, pageData) {
+  const array = []
+
+  var previousPageLink = `javascript:window.history.back()`
+  var previousPageText = 'Back'
+
+  if (previousPage) {
+    if (previousPage.includes('your-questions')) {
+
+      previousPageLink = `../../clear-empty`
+      previousPageText = 'Back to your questions'
+
+    } else if (previousPage.includes(pageIndex + '/check-question')) {
+
+      // This will take users back to check their question - from a change link journey
+      previousPageLink = `../../clear-empty`
+      previousPageText = 'Back to your questions'
+
+    } else if (previousPage.includes((pageIndex - 1) + '/check-question')) {
+
+      // This will take users back to the previous question summary page
+      previousPageLink = `../` + (pageIndex - 1) + `/check-question`
+      previousPageText = 'Back to check question ' + pageIndex
+
+    } else if (previousPage.includes((pageIndex + 1) + '/check-question')) {
+
+      // This will take users back to their questions - avoid a circular journey
+      previousPageLink = `../../clear-empty`
+      previousPageText = 'Back to your questions'
+
+    } else if (previousPage.includes(pageIndex + '/edit-answer-type')) {
+
+      previousPageLink = `edit-answer-type`
+      previousPageText = 'Back to what kind of answer you need' 
+
+    } else if (previousPage.includes((pageIndex + 1) + '/edit-answer-type')) {
+
+      previousPageLink = `../../clear-empty`
+      previousPageText = 'Back to your questions'
+
+    } else if (previousPage.includes(pageIndex + '/edit-settings')) {
+
+      previousPageLink = `edit-settings`
+
+      var inputType = pageData.type
+      if (inputType === 'personName') {
+        previousPageText = 'Back to ask for a person’s name'
+      } else if (inputType === 'address') {
+        previousPageText = 'Back to what kind of addresses'
+      } else if (inputType === 'date') {
+        previousPageText = 'Back to ask for a date of birth'
+      } else if (inputType === 'text') {
+        previousPageText = 'Back to amount of text'
+      } else if (inputType === 'select') {
+        previousPageText = 'Back to create a list of options'
+      } else {
+        previousPageText = 'Back to what kind of answer you need'
+      }
+
+    } else if (previousPage.includes(pageIndex + '/edit-select-question')) {
+
+      previousPageLink = `edit-select-question`
+      previousPageText = 'Back to what’s your question'
+
+    } else if (previousPage.includes(pageIndex + '/edit')) {
+
+      previousPageLink = `edit`
+      previousPageText = 'Back to edit question'
+
+    } else if (previousPage.includes(pageIndex + '/additional-guidance')) {
+
+      previousPageLink = `additional-guidance`
+      previousPageText = 'Back to add guidance'
+
+    }
+  }
+
+  array.push({
+    'previousPageLink': previousPageLink,
+    'previousPageText': previousPageText
+  })
+
+  console.log(array)
+
+  return array
+}
+
+module.exports = router

--- a/app/views/form-designer/pages/additional-guidance.html
+++ b/app/views/form-designer/pages/additional-guidance.html
@@ -7,15 +7,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if previousPage and ('check-question' in previousPage) %}
-    <a class="govuk-back-link" href="check-question" target="_parent">
-      Back
-    </a>
-  {% else %}
-    <a class="govuk-back-link" href="javascript:window.history.back()">
-      Back
-    </a>
-  {% endif %}
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}
@@ -174,17 +169,20 @@
           </p>
           {% endif %}
 
-
-          <!-- Continue or cancel button group -->
-          <div class="govuk-button-group">
-            {{ govukButton({
-              text: "Continue",
-              name: "action",
-              value: "editPage"
-            }) }}
-
-            <a class="govuk-link govuk-link--no-visited-state" href="edit">Cancel</a>
-          </div>
+          {{ govukButton({
+            text: "Continue",
+            name: "action",
+            value: "editPage"
+          }) }}
+        
+          {# If we are not sure what the back link is going to don’t show the bottom link #}
+          {% if previousPageText !== 'Back' %}
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+              {{ previousPageText }}
+            </a>
+          </p>
+          {% endif %}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -53,258 +53,253 @@
   {{pageTitle}} - Preview - GOV.UK
 {% endblock %}
 
+{# Overwrite back link if last action was to save #}
+{% if successMessage %}
+{% set previousPageText = 'Back to your questions' %}
+{% set previousPageLink = '../../clear-empty' %}
+{% endif %}
+
 {% block beforeContent %}
-  {% if previousPage and ('your-questions' in previousPage) %}
-    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
-      Back to your questions
-    </a>
-  {% elif previousPage and ('edit-answer-type' in previousPage) and (previousPage.split('/')|last == pageIndex|int + 1) %}
-    <a class="govuk-back-link" href="../{{pageIndex|int + 1}}/edit-answer-type" target="_parent">
-      Back
-    </a>
-  {% else %}
-    <a class="govuk-back-link" href="javascript:window.history.back()">
-      Back
-    </a>
-  {% endif %}
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <form id="form" class="form" method="post" novalidate>
 
-  <form id="form" class="form" method="post" novalidate>
-
-    {% if containsErrors %}
-      {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: errorList
-      }) }}
-    {% endif %}
-
-    {% if successMessage %}
-      {{ govukNotificationBanner({
-        type: 'success',
-        text: successMessage
-      }) }}
-    {% endif %}
-
-    <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
-    <h1 class="govuk-panel__title">{{pageTitle}}</h1>
-
-
-    <!-- Answer settings -->
-    <h2 class="govuk-heading-m">Answer settings</h2>
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Answer type
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{answerType}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit-answer-type">
-            Change <span class="govuk-visually-hidden">answer type {{answerType}}<span>
-          </a>
-        </dd>
-      </div>
-      {% if pageData['input'] %}
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          {{inputTypeTitle}}
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{inputType}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#input">
-            Change <span class="govuk-visually-hidden">{{inputTypeTitle}} {{inputType}}<span>
-          </a>
-        </dd>
-      </div>
+      {% if containsErrors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
       {% endif %}
-      {% if pageData['title'] %}
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Title needed
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{pageData['title']|capitalize}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#title">
-            Change <span class="govuk-visually-hidden">title needed {{pageData['title']|capitalize}}<span>
-          </a>
-        </dd>
-      </div>
+      
+      {% set html %}
+        <h3 class="govuk-notification-banner__heading">
+          {{ successMessage }}
+        </h3>
+        <ul class="govuk-list">
+          <li>
+            <a {% if 'new' in nextActionURL %}role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-3" data-module="govuk-button"{% else %}class="govuk-link govuk-link--no-visited-state"{% endif %} href="{{ nextActionURL }}">
+              {{ nextActionText }}
+            </a>
+          </li>
+          <li>
+            <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+              {{ previousPageText }}
+            </a>
+          </li>
+        </ul>
+      {% endset %}
+
+      {% if successMessage %}
+        {{ govukNotificationBanner({
+          type: 'success',
+          html: html
+        }) }}
       {% endif %}
-      {% if pageData['item-list'] %}
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Options
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {% if (pageData['item-list']|length|int >= 1) %}
-            {% for item in pageData['item-list'] %}{{item}}{% if not loop.last %}, {% endif %}{% endfor %}
-          {% else %}
-            No options added
-          {% endif %}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#option-0">
-            Change <span class="govuk-visually-hidden">options<span>
-          </a>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Only select one option
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') else 'No'}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#oneOption">
-            Change <span class="govuk-visually-hidden">only select one option<span>
-          </a>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Include 'none of the above' option
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') else 'No'}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#noneOption">
-            Change <span class="govuk-visually-hidden">include 'none of the above' option<span>
-          </a>
-        </dd>
-      </div>
+
+      <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
+      <h1 class="govuk-panel__title">{{pageTitle}}</h1>
+
+      <!-- Answer settings -->
+      <h2 class="govuk-heading-m">Answer settings</h2>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Answer type
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{answerType}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit-answer-type">
+              Change <span class="govuk-visually-hidden">answer type {{answerType}}<span>
+            </a>
+          </dd>
+        </div>
+        {% if pageData['input'] and (pageData['input'] !== '') %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            {{inputTypeTitle}}
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{inputType}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#input">
+              Change <span class="govuk-visually-hidden">{{inputTypeTitle}} {{inputType}}<span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+        {% if pageData['title'] and (pageData['type'] === 'personName') %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Title needed
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{pageData['title']|capitalize}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#title">
+              Change <span class="govuk-visually-hidden">title needed {{pageData['title']|capitalize}}<span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+        {% if pageData['item-list'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Options
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if (pageData['item-list']|length|int >= 1) %}
+              {% for item in pageData['item-list'] %}{{item}}{% if not loop.last %}, {% endif %}{% endfor %}
+            {% else %}
+              No options added
+            {% endif %}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#option-0">
+              Change <span class="govuk-visually-hidden">options<span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Only select one option
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') else 'No'}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#oneOption">
+              Change <span class="govuk-visually-hidden">only select one option<span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Include 'none of the above' option
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{'Yes' if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') else 'No'}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit-settings#noneOption">
+              Change <span class="govuk-visually-hidden">include 'none of the above' option<span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+      </dl>
+
+      <!-- Your question -->
+      <h2 class="govuk-heading-m">Your question</h2>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Question
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ pageData['long-title'] or 'Question text' }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit#long-title">
+              Change <span class="govuk-visually-hidden">Question {{ pageData['long-title'] or 'Question text' }}<span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Hint text (optional)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{pageData['hint-text'] or 'None added' }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit#hint-text">
+              Change <span class="govuk-visually-hidden">Hint text {{pageData['hint-text']}}<span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Add guidance
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{pageData['additional-guidance'] or 'No'}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit#additional-guidance">
+              Change <span class="govuk-visually-hidden">Add guidance {{pageData['additional-guidance']}}<span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Make this question optional
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ 'Yes' if data['questionOptional'] else 'No' }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="edit">
+              Change <span class="govuk-visually-hidden">if question optional<span>
+            </a>
+          </dd>
+        </div>
+      </dl>
+
+      {% if pageData['additional-guidance'] == 'Yes' %}
+      <!-- Guidance -->
+      <h2 class="govuk-heading-m">Guidance</h2>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Page heading
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{pageData['page-name']}}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="additional-guidance">
+              Change <span class="govuk-visually-hidden">Page heading {{pageData['page-name']}}<span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Guidance text
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ pageData['additional-guidance-text'] | striptags(true) | escape | nl2br }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--no-visited-state" href="additional-guidance">
+              Change <span class="govuk-visually-hidden">Guidance text {{pageData['additional-guidance-text']}}<span>
+            </a>
+          </dd>
+        </div>
+      </dl>
       {% endif %}
-    </dl>
 
-    <!-- Your question -->
-    <h2 class="govuk-heading-m">Your question</h2>
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Question
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ pageData['long-title'] or 'Question text' }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit#long-title">
-            Change <span class="govuk-visually-hidden">Question {{ pageData['long-title'] or 'Question text' }}<span>
-          </a>
-        </dd>
+      <input type="hidden" id="questionSaved" name="questionSaved" value="Yes" />
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text:  "Save question",
+          name: "action",
+          value: "update"
+        }) }}
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Hint text (optional)
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{pageData['hint-text'] or 'None added' }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit#hint-text">
-            Change <span class="govuk-visually-hidden">Hint text {{pageData['hint-text']}}<span>
-          </a>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Add guidance
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{pageData['additional-guidance'] or 'No'}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit#additional-guidance">
-            Change <span class="govuk-visually-hidden">Add guidance {{pageData['additional-guidance']}}<span>
-          </a>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Make this question optional
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ 'Yes' if data['questionOptional'] else 'No' }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="edit">
-            Change <span class="govuk-visually-hidden">if question optional<span>
-          </a>
-        </dd>
-      </div>
-    </dl>
 
-    {% if pageData['additional-guidance'] == 'Yes' %}
-    <!-- Guidance -->
-    <h2 class="govuk-heading-m">Guidance</h2>
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Page heading
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{pageData['page-name']}}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="additional-guidance">
-            Change <span class="govuk-visually-hidden">Page heading {{pageData['page-name']}}<span>
-          </a>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Guidance text
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ pageData['additional-guidance-text'] | striptags(true) | escape | nl2br }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="additional-guidance">
-            Change <span class="govuk-visually-hidden">Guidance text {{pageData['additional-guidance-text']}}<span>
-          </a>
-        </dd>
-      </div>
-    </dl>
-    {% endif %}
-
-    <div class="govuk-button-group">
-    {% if pageId >= data['highestPageId'] %}
-
-      {{ govukButton({
-        text: "Save and add next question",
-        name: "action",
-        value: "createNextPage"
-      }) }}
-
-    {% else %}
-
-      {{ govukButton({
-        text: "Save and edit next question",
-        name: "action",
-        value: "editNextPage"
-      }) }}
-
-    {% endif %}
-
-    {{ govukButton({
-      text:  "Save question",
-      name: "action",
-      value: "update",
-      classes: "govuk-button--secondary"
-    }) }}
-
-    </div>
-
-    {% if editingExistingQuestion %}
+      {% if editingExistingQuestion === 'Yes' %}
       {{ govukButton({
         text: "Delete question",
         classes: "govuk-button--warning",
@@ -312,11 +307,20 @@
         value: "deletePage"
       }) }}
 
-      {# Move go to your questions link only if a question is saved #}
       <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ nextActionURL }}">{{ nextActionText }}</a>
       </p>
-    {% endif %}
+      {% endif %}
+
+      {# If we are not sure what the back link is going to don’t show the bottom link #}
+      {% if previousPageText !== 'Back' %}
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+          {{ previousPageText }}
+        </a>
+      </p>
+      {% endif %}
+
     </form>
   </div>
 </div>

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -50,7 +50,7 @@
 {% endif %}
 
 {% block pageTitle %}
-  {{pageTitle}} - Preview - GOV.UK
+  {{ pageTitle }} - GOV.UK Forms
 {% endblock %}
 
 {# Overwrite back link if last action was to save #}
@@ -292,10 +292,18 @@
       <input type="hidden" id="questionSaved" name="questionSaved" value="Yes" />
 
       <div class="govuk-button-group">
+        {# Green CTA - Save question #}
         {{ govukButton({
           text:  "Save question",
           name: "action",
           value: "update"
+        }) }}
+        {# Grey CTA - Save and preview question #}
+        {{ govukButton({
+          classes: "govuk-button--secondary",
+          text:  "Save and preview",
+          name: "action",
+          value: "savePreview"
         }) }}
       </div>
 
@@ -308,7 +316,9 @@
       }) }}
 
       <p class="govuk-body">
-        <a class="govuk-link govuk-link--no-visited-state" href="{{ nextActionURL }}">{{ nextActionText }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ nextActionURL }}">
+          {{ nextActionText }}
+        </a>
       </p>
       {% endif %}
 

--- a/app/views/form-designer/pages/edit-answer-type.html
+++ b/app/views/form-designer/pages/edit-answer-type.html
@@ -13,36 +13,15 @@
 {% endset %}
 
 {% block beforeContent %}
-  {% if previousPage and ('your-questions' in previousPage) %}
-    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
-      Back to your questions
-    </a>
-  {% elif previousPage and ((pageIndex-1) + '/check-question' in previousPage) %}
-    <a class="govuk-back-link" href="../../clear-empty" target="_parent">
-      Back to your questions
-    </a>
-  {% elif previousPage and (pageIndex + '/check-question' in previousPage) %}
-    <a class="govuk-back-link" href="check-question" target="_parent">
-      Back
-    </a>
-  {% else %}
-    <a class="govuk-back-link" href="javascript:window.history.back()">
-      Back
-    </a>
-  {% endif %}
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-      {% if successMessage %}
-      {{ govukNotificationBanner({
-        type: 'success',
-        text: successMessage
-      }) }}
-      {% endif %}
-
       <form id="form" class="form" action="../{{pageId}}/edit-answer-type" method="post" novalidate>
 
         {% if containsErrors %}
@@ -137,9 +116,12 @@
           value: "editPage"
         }) }}
 
-        {% if ('your-questions' in previousPage) or ((pageIndex-1) + '/check-question' in previousPage) %}
+        {# If we are not sure what the back link is going to don’t show the bottom link #}
+        {% if previousPageText !== 'Back' %}
         <p class="govuk-body">
-          <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
+          <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+            {{ previousPageText }}
+          </a>
         </p>
         {% endif %}
 

--- a/app/views/form-designer/pages/edit-select-question.html
+++ b/app/views/form-designer/pages/edit-select-question.html
@@ -20,15 +20,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if previousPage and ('check-question' in previousPage) %}
-    <a class="govuk-back-link" href="check-question" target="_parent">
-      Back
-    </a>
-  {% else %}
-    <a class="govuk-back-link" href="javascript:window.history.back()">
-      Back
-    </a>
-  {% endif %}
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}
@@ -63,11 +58,18 @@
             errorMessage: { text: errors['long-title'].text } if errors['long-title'].text
           }) }}
 
-          <div class="govuk-button-group">
-              {{ govukButton({
-                text: "Continue"
-              }) }}
-          </div>
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+        
+          {# If we are not sure what the back link is going to don’t show the bottom link #}
+          {% if previousPageText !== 'Back' %}
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+              {{ previousPageText }}
+            </a>
+          </p>
+          {% endif %}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/edit-settings.html
+++ b/app/views/form-designer/pages/edit-settings.html
@@ -19,15 +19,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if previousPage and ('check-question' in previousPage) %}
-    <a class="govuk-back-link" href="check-question" target="_parent">
-      Back
-    </a>
-  {% else %}
-    <a class="govuk-back-link" href="javascript:window.history.back()">
-      Back
-    </a>
-  {% endif %}
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}
@@ -292,10 +287,16 @@
           name: "action",
           value: "editPage"
         }) }}
+        
+        {# If we are not sure what the back link is going to don’t show the bottom link #}
+        {% if previousPageText !== 'Back' %}
+        <p class="govuk-body">
+          <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+            {{ previousPageText }}
+          </a>
+        </p>
+        {% endif %}
 
-        {# <p class="govuk-body">
-          <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
-        </p> #}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/edit.html
+++ b/app/views/form-designer/pages/edit.html
@@ -58,15 +58,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% if previousPage and ('check-question' in previousPage) %}
-    <a class="govuk-back-link" href="check-question" target="_parent">
-      Back
-    </a>
-  {% else %}
-    <a class="govuk-back-link" href="javascript:window.history.back()">
-      Back
-    </a>
-  {% endif %}
+  {# Back links are handled in routes.js #}
+  <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">
+    {{ previousPageText }}
+  </a>
 {% endblock %}
 
 {% block content %}
@@ -179,10 +174,15 @@
             name: "action",
             value: "editPage"
           }) }}
-
-          {# <p class="govuk-body">
-            <a class="govuk-link govuk-link--no-visited-state" href="../../clear-empty">Go to your questions</a>
-          </p> #}
+        
+          {# If we are not sure what the back link is going to don’t show the bottom link #}
+          {% if previousPageText !== 'Back' %}
+          <p class="govuk-body">
+            <a class="govuk-link" href="{{ previousPageLink }}" target="_parent">
+              {{ previousPageText }}
+            </a>
+          </p>
+          {% endif %}
 
       </form>
     </div>

--- a/app/views/form-designer/pages/preview-question.html
+++ b/app/views/form-designer/pages/preview-question.html
@@ -1,0 +1,111 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set answerType = pageData['type']|capitalize %}
+{% if pageData['type'] === 'personName' %}
+  {% set answerType = 'Person’s name' %}
+  {% set inputTypeTitle = data.personNameInputTypeTitle %}
+  {% if pageData['input'] === 'single-field' %}
+    {% set inputType = 'Full name in a single box' %}
+  {% elif pageData['input'] === 'multi-field' %}
+    {% set inputType = 'First and last names in separate boxes' %}
+  {% elif pageData['input'] === 'multi-field-plus' %}
+    {% set inputType = 'First, middle and last names in separate boxes' %}
+  {% endif %}
+{% elif pageData['type'] === 'companyName' %}
+  {% set answerType = 'Company or organisation’s name' %}
+{% elif pageData['type'] === 'email' %}
+  {% set answerType = 'Email address' %}
+{% elif pageData['type'] === 'phone' %}
+  {% set answerType = 'Phone number' %}
+{% elif pageData['type'] === 'national-insurance-number' %}
+  {% set answerType = 'National Insurance number' %}
+{% elif pageData['type'] === 'address' %}
+  {% set inputTypeTitle = data.addressInputTypeTitle %}
+  {% if ('uk-address' in pageData['input']) and ('international-address' in pageData['input']) %}
+    {% set inputType = 'UK and international addresses' %}
+  {% elif 'uk-address' in pageData['input'] %}
+    {% set inputType = 'UK addresses' %}
+  {% elif 'international-address' in pageData['input'] %}
+    {% set inputType = 'International addresses' %}
+  {% endif %}
+{% elif pageData['type'] === 'date' %}
+  {% set inputTypeTitle = data.dateOfBirthInputTypeTitle %}
+  {% if pageData['input'] === 'yes' %}
+    {% set inputType = 'Yes' %}
+  {% else %}
+    {% set inputType = 'No' %}
+  {% endif %}
+{% elif pageData['type'] === 'select' %}
+  {% set answerType = 'Selection from a list' %}
+{% elif pageData['type'] === 'number' %}
+{% elif pageData['type'] === 'text' %}
+  {% set inputTypeTitle = data.textLengthInputTypeTitle %}
+  {% if pageData['input'] === 'single-line-input' %}
+    {% set inputType = 'A single line of text' %}
+  {% else %}
+    {% set inputType = 'More than a single line of text' %}
+  {% endif %}
+{% endif %}
+
+{% set pageTitle = 'Preview question' %}
+
+{% block pageTitle %}
+  {{ pageTitle }} {{ pageId | int + 1 }} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="check-question" target="_parent">
+    Back to check your question
+  </a>
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {% if successMessage %}
+      {{ govukNotificationBanner({
+        type: 'success',
+        text: successMessage
+      }) }}
+    {% endif %}
+
+    <span class="govuk-caption-l">Question {{ pageId | int + 1 }}</span>
+    <h1 class="govuk-panel__title">{{pageTitle}}</h1>
+
+    <p class="govuk-body">
+      This is how your question will look.
+    </p>
+
+    <p class="govuk-body">
+      Answer type: {{ answerType }}
+    </p>
+    {% if inputType %}
+    <p class="govuk-body">
+      Settings: {{ inputType }}
+    </p>
+    {% endif %}
+
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <!-- PREVIEW WINDOW -->
+    <div class="app-preview-pane-wrapper govuk-!-margin-bottom-7">
+      {% include './preview.html' %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <a role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-3" data-module="govuk-button" href="{{ nextActionURL }}">
+        {{ nextActionText }}
+      </a>
+    </p>
+    <p class="govuk-body">
+      <a class="govuk-link" href="check-question" target="_parent">
+        Back to check your question
+      </a>
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/form-designer/pages/preview.html
+++ b/app/views/form-designer/pages/preview.html
@@ -4,224 +4,241 @@
   NOTE: button should be disabled in this view only.
   Should look at a way to make a single re-usable content block for these two screens.
 #}
-{% extends "layout-body-only.html" %}
+{# {% extends "layout-body-only.html" %} #}
+
+{# Use the unbranded to stop pulling in ALL the head HTML again #}
+{% extends "layout-unbranded-preview.html" %}
+
+{# set the form name as the service name in the header #}
+{% set serviceName = data.formTitle %}
+
+{# set the page title to the question/heading added by the form creator #}
+{% if pageData['additional-guidance'] == 'Yes' %}
+  {% set pageHeading = pageData['page-name'] or 'Guidance text' %}
+  {% if pageData['additional-guidance-text'] %}
+    {% set markdownContent = pageData['additional-guidance-text'] %}
+  {% endif %}
+{% endif %}
 
 {% set pageTitle = pageData['long-title'] or 'Question text' %}
+{% if pageData['questionOptional'] %}
+  {% set pageTitle = pageTitle + ' (optional)' %}
+{% endif %}
 
 {% block pageTitle %}
-  {{ pageTitle }} - GOV.UK Forms
-{% endblock %}
-
-{% block header %}{% endblock %}
-
-{% block beforeContent %}
+  {% if pageHeading %}{{ pageHeading }}{% else %}{{ pageTitle }}{% endif %} - Preview - {{ data.formTitle or '[formTitle]' }} - GOV.UK
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row app-preview-pane">
     <div class="govuk-grid-column-two-thirds">
-      <form class="form" method="post" novalidate>
+      {% if pageData['additional-guidance'] == 'Yes' %}
+        <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+        {% markdown %}{{ markdownContent }}{% endmarkdown %}
+      {% endif %}
 
-        {#
-
+      {#
         Every field id is prefixed with a unique page id.
         So we can have separate configurations for every page.
+      #}
 
-        #}
+      {# If the page has no intro, set the heading inside of the macros #}
+      {# The heading doubles up as the label #}
+      {% set label = {
+        text: pageTitle,
+        classes: "govuk-label--l" if pageData['additional-guidance'] != 'Yes' else "govuk-label--m",
+        isPageHeading: true if pageData['additional-guidance'] != 'Yes'
+      }%}
 
-        {# If the page has no intro, set the heading inside of the macros #}
-        {# The heading doubles up as the label #}
-        {% set label = {
-          text: pageTitle,
-          classes: "govuk-label--l",
-          isPageHeading: true
-        }%}
-
-        {# Full name in a single field #}
-        {% if pageData['type'] === 'personName' %}
-          {% if (pageData['input'] === 'multi-field') or (pageData['input'] === 'multi-field-plus') %}
-
-            {% call govukFieldset({
-              legend: {
-                text: pageTitle,
-                classes: "govuk-fieldset__legend--l",
-                isPageHeading: true
-              }
-            }) %}
-
-              {% if pageData['hint-text'] %}
-              <p class="govuk-hint">{{pageData['hint-text']}}</p>
-              {% endif %}
-
-              {% if pageData['title'] === 'yes' %}
-              {{ govukInput({
-                label: {
-                  html: 'Title'
-                },
-                classes: "govuk-!-width-one-quarter",
-                id: pageId + "-name-title",
-                name: pageId + "-name-title",
-                autocomplete: "honorific-prefix",
-                value: data[(pageId | int) + "-name-title"]
-              }) }}
-              {% endif %}
-
-              {{ govukInput({
-                label: {
-                  html: 'First name'
-                },
-                classes: "govuk-!-width-one-half",
-                id: pageId + "-first-name",
-                name: pageId + "-first-name",
-                autocomplete: "given-name",
-                value: data[(pageId | int) + "-first-name"]
-              }) }}
-
-              {% if pageData['input'] === 'multi-field-plus' %}
-              {{ govukInput({
-                label: {
-                  html: 'Middle names'
-                },
-                classes: "govuk-!-width-two-thirds",
-                id: pageId + "-middle-names",
-                name: pageId + "-middle-names",
-                autocomplete: "additional-name",
-                value: data[(pageId | int) + "-middle-names"]
-              }) }}
-              {% endif %}
-
-              {{ govukInput({
-                label: {
-                  html: 'Last name'
-                },
-                classes: "govuk-!-width-one-half",
-                id: pageId + "-last-name",
-                name: pageId + "-last-name",
-                autocomplete: "family-name",
-                value: data[(pageId | int) + "-last-name"]
-              }) }}
-
-            {% endcall %}
-
-          {% elif (pageData['input'] === 'single-field') and (pageData['title'] === 'yes') %}
-
-            {% call govukFieldset({
-              legend: {
-                text: pageTitle,
-                classes: "govuk-fieldset__legend--l",
-                isPageHeading: true
-              }
-            }) %}
-
-              {% if pageData['hint-text'] %}
-              <p class="govuk-hint">{{pageData['hint-text']}}</p>
-              {% endif %}
-
-              {{ govukInput({
-                label: {
-                  html: 'Title'
-                },
-                classes: "govuk-!-width-one-quarter",
-                id: pageId + "-name-title",
-                name: pageId + "-name-title",
-                autocomplete: "honorific-prefix",
-                value: data[(pageId | int) + "-name-title"]
-              }) }}
-
-              {{ govukInput({
-                label: {
-                  html: 'Full name'
-                },
-                id: pageId + "-full-name",
-                name: pageId + "-full-name",
-                autocomplete: "name",
-                value: data[(pageId | int) + "-full-name"]
-              }) }}
-
-            {% endcall %}
-
-          {% else %}
-
-            {{ govukInput({
-              label: label,
-              id: pageId + "-full-name",
-              name: pageId + "-full-name",
-              hint: {
-                text: pageData['hint-text']
-              },
-              autocomplete: "name",
-              value: data[(pageId | int) + "-full-name"]
-            }) }}
-
-          {% endif %}
-
-        {% endif %}
-
-        {# Company or organisation’s name #}
-        {% if pageData['type'] === 'companyName' %}
-          {{ govukInput({
-            label: label,
-            hint: {text: pageData['hint-text']},
-            id: pageId,
-            name: pageId,
-            autocomplete: "organization",
-            value: data[pageId | int]
-          }) }}
-        {% endif %}
-
-        {% if pageData['type'] == 'email' %}
-          {{ govukInput({
-            label: label,
-            hint: { text: pageData['hint-text'] },
-            id: pageId,
-            name: pageId,
-            type: "email",
-            autocomplete: "email",
-            spellcheck: false,
-            value: data[pageId | int]
-          }) }}
-        {% endif %}
-
-        {% if pageData['type'] == 'phone' %}
-          {{ govukInput({
-            label: label,
-            hint: { text: pageData['hint-text'] },
-            id: pageId,
-            name: pageId,
-            type: "tel",
-            autocomplete: "tel",
-            classes: "govuk-input--width-20",
-            value: data[pageId | int]
-          }) }}
-        {% endif %}
-
-        {% if pageData['type'] == 'national-insurance-number' %}
-          {{ govukInput({
-            label: label,
-            hint: { text: pageData['hint-text'] },
-            classes: "govuk-input--width-10",
-            id: pageId,
-            name: pageId,
-            spellcheck: false,
-            value: data[pageId | int]
-          }) }}
-        {% endif %}
-
-        {% if pageData['type'] == 'address' %}
+      {# Full name in a single field #}
+      {% if pageData['type'] === 'personName' %}
+        {% if (pageData['input'] === 'multi-field') or (pageData['input'] === 'multi-field-plus') %}
 
           {% call govukFieldset({
             legend: {
               text: pageTitle,
-              classes: "govuk-fieldset__legend--l",
-              isPageHeading: true
+              classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+              isPageHeading: true if pageData['additional-guidance'] != 'Yes'
             }
           }) %}
 
           {% if pageData['hint-text'] %}
-          <p class="govuk-hint">{{pageData['hint-text']}}</p>
+            <p class="govuk-hint">{{ pageData['hint-text'] }}</p>
           {% endif %}
 
-          {% if ('uk-address' in pageData['input']) and not ('international-address' in pageData['input']) %}
+          {% if pageData['title'] === 'yes' %}
+            {{ govukInput({
+                label: {
+                  html: 'Title'
+                },
+                classes: "govuk-!-width-one-quarter",
+                id: pageId + "-name-title",
+                name: pageId + "-name-title",
+                autocomplete: "honorific-prefix",
+                value: data[(pageId | int) + "-name-title"]
+              }) }}
+          {% endif %}
+
+          {{ govukInput({
+            label: {
+              html: 'First name'
+            },
+            classes: "govuk-!-width-one-half",
+            id: pageId + "-first-name",
+            name: pageId + "-first-name",
+            autocomplete: "given-name",
+            value: data[(pageId | int) + "-first-name"]
+          }) }}
+
+          {% if pageData['input'] === 'multi-field-plus' %}
+            {{ govukInput({
+              label: {
+                html: 'Middle names'
+              },
+              classes: "govuk-!-width-two-thirds",
+              id: pageId + "-middle-names",
+              name: pageId + "-middle-names",
+              autocomplete: "additional-name",
+              value: data[(pageId | int) + "-middle-names"]
+            }) }}
+          {% endif %}
+
+          {{ govukInput({
+            label: {
+              html: 'Last name'
+            },
+            classes: "govuk-!-width-one-half",
+            id: pageId + "-last-name",
+            name: pageId + "-last-name",
+            autocomplete: "family-name",
+            value: data[(pageId | int) + "-last-name"]
+          }) }}
+
+          {% endcall %}
+
+        {% elif (pageData['input'] === 'single-field') and (pageData['title'] === 'yes') %}
+
+          {% call govukFieldset({
+            legend: {
+              text: pageTitle,
+              classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+              isPageHeading: true if pageData['additional-guidance'] != 'Yes'
+            }
+          }) %}
+
+          {% if pageData['hint-text'] %}
+            <p class="govuk-hint">{{pageData['hint-text']}}</p>
+          {% endif %}
+
+          {{ govukInput({
+            label: {
+              html: 'Title'
+            },
+            classes: "govuk-!-width-one-quarter",
+            id: pageId + "-name-title",
+            name: pageId + "-name-title",
+            autocomplete: "honorific-prefix",
+            value: data[(pageId | int) + "-name-title"]
+          }) }}
+
+          {{ govukInput({
+            label: {
+              html: 'Full name'
+            },
+            id: pageId + "-full-name",
+            name: pageId + "-full-name",
+            autocomplete: "name",
+            value: data[(pageId | int) + "-full-name"]
+          }) }}
+
+          {% endcall %}
+
+        {% else %}
+
+          {{ govukInput({
+            label: label,
+            id: pageId + "-full-name",
+            name: pageId + "-full-name",
+            hint: {
+              text: pageData['hint-text']
+            },
+            autocomplete: "name",
+            value: data[(pageId | int) + "-full-name"]
+          }) }}
+
+        {% endif %}
+
+      {% endif %}
+
+      {# Company or organisation’s name #}
+      {% if pageData['type'] === 'companyName' %}
+        {{ govukInput({
+          label: label,
+          hint: {text: pageData['hint-text']},
+          id: pageId,
+          name: pageId,
+          autocomplete: "organization",
+          value: data[pageId | int]
+        }) }}
+      {% endif %}
+
+      {# EMAIL ADDRESS #}
+      {% if pageData['type'] == 'email' %}
+        {{ govukInput({
+          label: label,
+          hint: { text: pageData['hint-text'] },
+          id: pageId,
+          name: pageId,
+          type: "email",
+          autocomplete: "email",
+          spellcheck: false,
+          value: data[pageId | int]
+        }) }}
+      {% endif %}
+
+      {# PHONE NUMBER #}
+      {% if pageData['type'] == 'phone' %}
+        {{ govukInput({
+          label: label,
+          hint: { text: pageData['hint-text'] },
+          id: pageId,
+          name: pageId,
+          type: "tel",
+          autocomplete: "tel",
+          classes: "govuk-input--width-20",
+          value: data[pageId | int]
+        }) }}
+      {% endif %}
+
+      {# NATIONAL INSURANCE NUMBER (NINO) #}
+      {% if pageData['type'] == 'national-insurance-number' %}
+        {{ govukInput({
+          label: label,
+          hint: { text: pageData['hint-text'] },
+          classes: "govuk-input--width-10",
+          id: pageId,
+          name: pageId,
+          spellcheck: false,
+          value: data[pageId | int]
+        }) }}
+      {% endif %}
+
+      {# ADDRESS #}
+      {% if pageData['type'] == 'address' %}
+
+        {% call govukFieldset({
+          legend: {
+            text: pageTitle,
+            classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+            isPageHeading: true if pageData['additional-guidance'] != 'Yes'
+          }
+        }) %}
+
+        {% if pageData['hint-text'] %}
+          <p class="govuk-hint">{{pageData['hint-text']}}</p>
+        {% endif %}
+
+        {% if ('uk-address' in pageData['input']) and not ('international-address' in pageData['input']) %}
           {{ govukInput({
             label: {
               html: 'Address line 1'
@@ -274,8 +291,8 @@
             value: data[(pageId | int) + '-address-postcode']
           }) }}
 
-          {#{% elif 'international-address' in pageData['input'] %}#}
-          {% else %}
+        {% else %}
+          {# INTERNATIONAL ADDRESS OR BOTH #}
 
           {{ govukTextarea({
             label: {
@@ -298,13 +315,13 @@
             value: data[(pageId | int) + '-address-country-name']
           }) }}
 
-          {% endif %}
-
-          {% endcall %}
         {% endif %}
 
-        {# Date field #}
-        {% if pageData['type'] == 'date' %}
+        {% endcall %}
+      {% endif %}
+
+      {# DATE #}
+      {% if pageData['type'] == 'date' %}
 
         {% set day = pageId + '-day' %}
         {% set month = pageId + '-month' %}
@@ -312,7 +329,7 @@
 
         {% set neValue %}{{data[pageId + '-day'] + '/' + data[pageId + '-month'] + '/' + data[pageId + '-year']}}{% endset %}
 
-          {{ govukDateInput({
+        {{ govukDateInput({
           id: pageId,
           namePrefix: pageId,
           fieldset: {
@@ -340,16 +357,18 @@
             }
           ]
         }) }}
-        {% endif %}
 
-        {#
+      {% endif %}
+
+      {#
           For radios and checkboxes I'm using straight HTML,
           because I'm not smart enough to loop over the array
           and build an object to stick into a macro.
         #}
 
-        {# Radios #}
-        {% if (pageData['type'] === 'select' and pageData['oneOption']) or (pageData['type'] === 'yesorno') %}
+      {# RADIOS #}
+      {% if (pageData['type'] === 'select' and pageData['listSettings'].includes('oneOption')) 
+        or(pageData['type'] === 'yesorno') %}
 
         {% if pageData['type'] === 'yesorno' %}
           {% set itemsArray = ['Yes', 'No'] %}
@@ -363,7 +382,8 @@
             {% if not pageData['intro-text'] %}
               <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                 <h1 class="govuk-fieldset__heading">
-                  {{ pageTitle }} <span class="govuk-visually-hidden">preview</span>
+                  {{ pageTitle }}
+                  <span class="govuk-visually-hidden">preview</span>
                 </h1>
               </legend>
             {% endif %}
@@ -371,85 +391,105 @@
             <div id="question-{{pageId}}-hint" class="govuk-hint">
               {{ pageData['hint-text']}}
             </div>
-            <div class="govuk-radios">
+            <div class="govuk-radios" data-module="govuk-radios">
               {% for itemRaw in itemsArray %}
-              {% set item = itemRaw | trim %}
+                {% set item = itemRaw | trim %}
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}" {{ checked(pageId, item) }}>
+                  <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}">
                   <label class="govuk-label govuk-radios__label" for="{{ pageId }}-{{ item }}">
                     {{ item }}
                   </label>
                 </div>
               {% endfor %}
-            </div>
-          </fieldset>
-        </div>
-        {% endif %}
-
-        {# Checkboxes #}
-        {% if pageData['type'] == 'select' and not pageData['oneOption'] %}
-        {% set itemsArray = pageData['item-list'] %}
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
-
-            {% if not pageData['intro-text'] %}
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                <h1 class="govuk-fieldset__heading">{{ pageTitle }}</h1>
-              </legend>
-            {% endif %}
-
-            <div id="question-{{pageId}}-hint" class="govuk-hint">
-              {{ pageData['hint-text']}}
-            </div>
-            <div class="govuk-checkboxes">
-              {% if pageData['item-list'] %}
-                {% for item in itemsArray %}
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                  <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
-                    {{ item }}
+              {% if pageData['listSettings'].includes('noneOption')%}
+                <div class="govuk-radios__divider">or</div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="radio" value="none" data-behaviour="exclusive">
+                  <label class="govuk-label govuk-radios__label" for="question-{{pageId}}-none">
+                    None of the above
                   </label>
                 </div>
-                {% endfor %}
-              {% else %}
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
-                  <i>Blank</i>
-                </label>
+                {%endif%}
               </div>
-              <div class="govuk-checkboxes__item">
-                <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
-                  <i>Blank</i>
-                </label>
-              </div>
+            </fieldset>
+          </div>
+        {% endif %}
+
+        {# CHECKBOXES #}
+        {% if pageData['type'] == 'select' and not pageData['listSettings'].includes('oneOption') %}
+
+          {% set itemsArray = pageData['item-list'] %}
+
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
+
+              {% if not pageData['intro-text'] %}
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <h1 class="govuk-fieldset__heading">{{ pageTitle }}</h1>
+                </legend>
               {% endif %}
-            </div>
-          </fieldset>
-        </div>
+
+              <div id="question-{{pageId}}-hint" class="govuk-hint">
+                {{ pageData['hint-text'] }}
+              </div>
+              <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                {% if pageData['item-list'] %}
+                  {% for item in itemsArray %}
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
+                      {{ item }}
+                    </label>
+                  </div>
+                  {% endfor %}
+                  {% if pageData['listSettings'].includes('noneOption') %}
+                  <div class="govuk-checkboxes__divider">or</div>
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="checkbox" value="none" data-behaviour="exclusive">
+                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-none">
+                      None of the above
+                    </label>
+                  </div>
+                  {% endif %}
+                {% else %}
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                      <i>Blank</i>
+                    </label>
+                  </div>
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                      <i>Blank</i>
+                    </label>
+                  </div>
+                {% endif %}
+              </div>
+            </fieldset>
+          </div>
         {% endif %}
 
-        {# Number fields #}
+        {# NUMBER #}
         {% if pageData['type'] == 'number' %}
-        {{ govukInput({
-          label: label,
-          hint: {text: pageData['hint-text']},
-          id: pageId,
-          name: pageId,
-          inputmode: "numeric",
-          pattern: "[0-9]*",
-          spellcheck: false,
-          value: data[pageId | int]
-        }) }}
+          {{ govukInput({
+            label: label,
+            hint: {text: pageData['hint-text']},
+            id: pageId,
+            name: pageId,
+            inputmode: "numeric",
+            pattern: "[0-9]*",
+            spellcheck: false,
+            value: data[pageId | int]
+          }) }}
         {% endif %}
 
-        {# Text information fields #}
-        {% if pageData['type'] === 'text' %}
-          {% if pageData['input'] === 'single-line-input' %}
+          {# TEXT #}
+          {% if pageData['type'] === 'text' %}
+            {% if pageData['input'] === 'single-line-input' %}
 
-            {# Single line text fields #}
-            {{ govukInput({
+              {# Single line text fields #}
+              {{ govukInput({
               label: label,
               hint: {text: pageData['hint-text']},
               id: pageId,
@@ -457,24 +497,24 @@
               value: data[pageId | int]
             }) }}
 
-          {% else %}
+            {% else %}
 
-            {# Keeping the character limit options for now in case we want to test it later #}
+              {# Keeping the character limit options for now in case we want to test it later #}
 
-            {# Textarea with character limit #}
-            {# {% if pageData['char-limit'] == 'none' %}
-              {{ govukTextarea({
+              {# Textarea with character limit #}
+              {# {% if pageData['char-limit'] == 'none' %}
+            {{ govukTextarea({
               label: label,
               hint: {text: pageData['hint-text']},
               id: pageId,
               name: pageId,
               value: data[pageId | int]
             }) }}
-            {% endif %} #}
+          {% endif %} #}
 
-            {# Textarea with no character limit #}
-            {# {% if not (pageData['char-limit'] == 'none') %}
-              {{ govukCharacterCount({
+              {# Textarea with no character limit #}
+              {# {% if not (pageData['char-limit'] == 'none') %}
+            {{ govukCharacterCount({
               name: pageId,
               id: pageId,
               maxlength: pageData['char-limit'],
@@ -482,74 +522,37 @@
               hint: {text: pageData['hint-text']},
               value: data[pageId | int]
             }) }}
-            {% endif %} #}
+          {% endif %} #}
 
-            {# Textarea no, no, there's no limits #}
-            {{ govukTextarea({
-              name: pageId,
-              id: pageId,
-              label: label,
-              hint: {text: pageData['hint-text']},
-              value: data[pageId | int]
-            }) }}
+              {# Textarea no, no, there's no limits #}
+              {{ govukTextarea({
+            name: pageId,
+            id: pageId,
+            label: label,
+            hint: {text: pageData['hint-text']},
+            value: data[pageId | int]
+          }) }}
 
+            {% endif %}
           {% endif %}
-        {% endif %}
 
-        {# Help text #}
-        {% if pageData['help-text'] %}
-        {% set helpTextHtml %}
-        <div class="app-prose-scope">
-          {% markdown %}
-          {{ pageData['help-text'] }}
-          {% endmarkdown %}
+          {# HELP TEXT #}
+          {% if pageData['help-text'] %}
+
+            {% set helpTextHtml %}
+            <div class="app-prose-scope">
+              {% markdown %}
+              {{ pageData['help-text'] }}
+              {% endmarkdown %}
+            </div>
+            {% endset -%}
+
+            {{ govukDetails({
+            summaryText: "More information about this question",
+            html: helpTextHtml
+          }) }}
+          {% endif %}
+
         </div>
-        {% endset -%}
-
-        {{ govukDetails({
-          summaryText: "More information about this question",
-          html: helpTextHtml
-        }) }}
-        {% endif %}
-
-        {# Submit button #}
-        {{ govukButton({
-          text: "Continue",
-          disabled: true
-        }) }}
-
-        {% if data['supportDetails'] %}
-        {% set supportTextHtml %}
-        <div class="app-prose-scope">
-          {% if 'email' in data['supportDetails'] -%}
-          <h3 class="govuk-heading-s">Email</h3>
-          <p class="govuk-body">
-            <a class="govuk-link" href="mailto:{{data['emailSupport'] or 'support@department.gov.uk' | safe}}">{{data['emailSupport'] or 'support@department.gov.uk' | safe}}</a>
-          </p>
-          {%- endif %}
-          {% if 'phone' in data['supportDetails'] -%}
-          <h3 class="govuk-heading-s">Phone</h3>
-          <p class="govuk-body">{{data['phoneSupport'] | striptags(true) | escape | nl2br }}</p>
-          <p class="govuk-body">
-            <a class="govuk-link" href="https://www.gov.uk/call-charges" target="_blank">Find out about call charges</a>
-          </p>
-          {%- endif %}
-          {% if 'online' in data['supportDetails'] -%}
-          <h3 class="govuk-heading-s">Online</h3>
-          <p class="govuk-body">
-            <a class="govuk-link" href="{{data['onlineSupportLink']}}" target="_blank">{{data['onlineSupportText'] | safe}} (opens in new tab)</a>
-          </p>
-          {%- endif %}
-        </div>
-        {% endset -%}
-
-        {{ govukDetails({
-          summaryText: "Get help with this form",
-          html: supportTextHtml
-        }) }}
-        {% endif %}
-
-      </form>
-    </div>
-  </div>
-{% endblock %}
+      </div>
+    {% endblock %}

--- a/app/views/form-designer/your-questions.html
+++ b/app/views/form-designer/your-questions.html
@@ -96,6 +96,7 @@
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-padding-bottom-6">
             <div class="govuk-button-group form-action-group app-page-list__button-group">
+              {% if data.pages.length > 1 %}
               <div class="form-actions-reordering">
                 {% if page.pageIndex > 0 %}
                 {{ govukButton({
@@ -113,6 +114,7 @@
                 }) }}
                 {% endif %}
               </div>
+              {% endif %}
             </div>
             <a class="govuk-link govuk-link--no-visited-state" href="pages/{{ page.pageIndex | int }}/check-question">
               Edit<span class="govuk-visually-hidden"> Question {{loop.index}}. {{questionTitle}}</span>

--- a/app/views/layout-unbranded-preview.html
+++ b/app/views/layout-unbranded-preview.html
@@ -1,4 +1,4 @@
-{% extends "govuk-prototype-kit/layouts/govuk-branded.html" %}
+{% extends "govuk-prototype-kit/layouts/unbranded.html" %}
 
 {% block head %}{% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "govuk-prototype-kit",
       "dependencies": {
+        "@govuk-prototype-kit/common-templates": "1.2.2",
         "@govuk-prototype-kit/step-by-step": "^2.1.0",
         "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
         "govuk-frontend": "^4.7.0",
@@ -16,6 +17,11 @@
         "marked": "^4.2.12",
         "notifications-node-client": "^6.0.0"
       }
+    },
+    "node_modules/@govuk-prototype-kit/common-templates": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@govuk-prototype-kit/common-templates/-/common-templates-1.2.2.tgz",
+      "integrity": "sha512-VGk7dQhtAk9SvlsG5DPawAifRcM+aPHykH595zJomf8Upvn4DIIQfdLEDMHAr3b6d4BPpF5Cho5G5TGhyHXddg=="
     },
     "node_modules/@govuk-prototype-kit/step-by-step": {
       "version": "2.1.0",
@@ -3723,6 +3729,11 @@
     }
   },
   "dependencies": {
+    "@govuk-prototype-kit/common-templates": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@govuk-prototype-kit/common-templates/-/common-templates-1.2.2.tgz",
+      "integrity": "sha512-VGk7dQhtAk9SvlsG5DPawAifRcM+aPHykH595zJomf8Upvn4DIIQfdLEDMHAr3b6d4BPpF5Cho5G5TGhyHXddg=="
+    },
     "@govuk-prototype-kit/step-by-step": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@govuk-prototype-kit/step-by-step/-/step-by-step-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "name": "govuk-prototype-kit",
   "dependencies": {
+    "@govuk-prototype-kit/common-templates": "1.2.2",
     "@govuk-prototype-kit/step-by-step": "^2.1.0",
     "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
     "govuk-frontend": "^4.7.0",


### PR DESCRIPTION
## Preview

https://forms-prototypes-pr-208.herokuapp.com/

## What

- Added new [CTA design work from the Mural](https://app.mural.co/t/gaap0347/m/gaap0347/1698835640099/6343df85f7816e0f9d711bd8dc144cd004ea5bce?wid=0-1699284569672)
  - this includes simplifying the save call to actions to be a single action
  - added the new next steps to the success banner (Add/Edit next question) 
  - updated back links to show the page the user should be taken back to, reducing the likelihood of them just seeing “Back” without context
- Added new “Save and preview” button to “Check your question” page
- Added new “Preview question” page
  - includes a <div> showing what the question will look like to the end user minus any back/continue interactions as per the [new preview designs on Mural](https://app.mural.co/t/gaap0347/m/gaap0347/1684744172504/f76417fddf1f3af0411a7769286931d0298176de?wid=0-1691573668953)

## Why

Designs implemented to align with where the development environment is with regards to the new CTA and back link work. This will allow us to test this when we test the new preview question page as part of the add/edit a question journey with users in the next round of research [TBC].

## Still needs done

Once we have the content for each answer type for the preview question page, we will need to add this in. It will need to be implemented before testing.