### PR TITLE
2024 01 30 previewing a question unique content

### DIFF
--- a/app/views/form-designer/pages/_routes.js
+++ b/app/views/form-designer/pages/_routes.js
@@ -449,6 +449,8 @@ router.post('/form-designer/pages/:pageId(\\d+)/edit', function (req, res) {
   req.session.data['additional-guidance'] = undefined
 
   // if question is made optional, add it to pageData
+  //reset if question is optional each time the form creator comes back to edit a question, to make sure if they unselect the checkbox it’ll update correctly
+  pageData['questionOptional'] = undefined
   if (req.session.data['questionOptional']) {
     pageData['questionOptional'] = req.session.data['questionOptional']
   }

--- a/app/views/form-designer/pages/check-question.html
+++ b/app/views/form-designer/pages/check-question.html
@@ -246,7 +246,7 @@
             Make this question optional
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ 'Yes' if data['questionOptional'] else 'No' }}
+            {{ 'Yes' if (pageData['questionOptional'] and 'questionOptional' in pageData['questionOptional']) else 'No' }}
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link govuk-link--no-visited-state" href="edit">

--- a/app/views/form-designer/pages/edit.html
+++ b/app/views/form-designer/pages/edit.html
@@ -156,6 +156,9 @@
                   classes: "govuk-fieldset__legend--m"
                 }
               },
+              hint: {
+                text: "All questions are mandatory unless you make them optional."
+              },
               items: [
                 {
                   value: "questionOptional",

--- a/app/views/form-designer/pages/preview-question.html
+++ b/app/views/form-designer/pages/preview-question.html
@@ -1,49 +1,65 @@
 {% extends "layout-govuk-forms.html" %}
 
-{% set answerType = pageData['type']|capitalize %}
 {% if pageData['type'] === 'personName' %}
-  {% set answerType = 'Person’s name' %}
-  {% set inputTypeTitle = data.personNameInputTypeTitle %}
-  {% if pageData['input'] === 'single-field' %}
-    {% set inputType = 'Full name in a single box' %}
-  {% elif pageData['input'] === 'multi-field' %}
-    {% set inputType = 'First and last names in separate boxes' %}
-  {% elif pageData['input'] === 'multi-field-plus' %}
-    {% set inputType = 'First, middle and last names in separate boxes' %}
+  {% if pageData['input'] === 'multi-field-plus' %}
+    {% if pageData['title'] === 'yes' %}
+      {# IF ‘FIRST, MIDDLE AND LAST NAME’ AND ‘TITLE’ ARE SELECTED AND Q IS NOT OPTIONAL THEN: #}
+      {% set answerTypeInformation = 'People will be able to use any characters in their answers - including special characters. They can leave ‘title’ and ‘middle names’ empty if they need to.' %}
+    {% else %}
+      {# IF ‘FIRST, MIDDLE AND LAST NAME’ IS SELECTED BUT NOT ‘TITLE’ AND Q IS NOT OPTIONAL THEN: #}
+      {% set answerTypeInformation = 'People will be able to use any characters in their answers - including special characters. They can leave ‘middle names’ empty if they need to. ' %}
+    {% endif %}
+  {% elif pageData['title'] === 'yes' %}
+    {# IF ‘TITLE’ IS SELECTED BUT NOT ‘FIRST, MIDDLE AND LAST NAME’ AND Q IS NOT OPTIONAL THEN: #}
+    {% set answerTypeInformation = 'People will be able to use any characters in their answers - including special characters. They can leave ‘title’ empty if they need to.' %}
+  {% elif pageData['input'] === 'single-field' %}
+    {# IF ‘FULL NAME IN A SINGLE BOX’ IS SELECTED BUT NOT ‘TITLE’ THEN: #}
+    {% set answerTypeInformation = 'People will be able to use any characters in their answer - including special characters.' %}
+  {% else %}
+    {# OTHERWISE: #}
+    {% set answerTypeInformation = 'People will be able to use any characters in their answers - including special characters.' %}
   {% endif %}
 {% elif pageData['type'] === 'companyName' %}
-  {% set answerType = 'Company or organisation’s name' %}
+  {% set answerTypeInformation = 'People will be able to use any characters in their answer - including special characters.' %}
 {% elif pageData['type'] === 'email' %}
-  {% set answerType = 'Email address' %}
+  {% set answerTypeInformation = 'People will only be able to enter an answer that’s in the format of an email address, like name@example.com.' %}
 {% elif pageData['type'] === 'phone' %}
-  {% set answerType = 'Phone number' %}
+  {% set answerTypeInformation = 'People will be able to enter between 8 and 15 characters. They can use numbers, spaces, ‘ext’, ‘-’, ‘+’, ‘(’ and ‘)’.' %}
 {% elif pageData['type'] === 'national-insurance-number' %}
-  {% set answerType = 'National Insurance number' %}
+  {% set answerTypeInformation = 'People will only be able to enter an answer that’s in the format of a National Insurance number - 2 letters, 6 numbers, then A, B, C or D.' %}
 {% elif pageData['type'] === 'address' %}
-  {% set inputTypeTitle = data.addressInputTypeTitle %}
-  {% if ('uk-address' in pageData['input']) and ('international-address' in pageData['input']) %}
-    {% set inputType = 'UK and international addresses' %}
-  {% elif 'uk-address' in pageData['input'] %}
-    {% set inputType = 'UK addresses' %}
-  {% elif 'international-address' in pageData['input'] %}
-    {% set inputType = 'International addresses' %}
+  {% if ('uk-address' in pageData['input']) and not ('international-address' in pageData['input']) %}
+    {# IF UK SELECTED: #}
+    {% set answerTypeInformation = 'People will only be able to enter a postcode that’s in the format of a UK postcode.' %}
+  {% else %}
+    {# IF INTERNATIONAL SELECTED: #}
+    {% set answerTypeInformation = 'People will be able to answer using the appropriate format for the address. This is useful if you expect any international addresses. ' %}
   {% endif %}
 {% elif pageData['type'] === 'date' %}
-  {% set inputTypeTitle = data.dateOfBirthInputTypeTitle %}
   {% if pageData['input'] === 'yes' %}
-    {% set inputType = 'Yes' %}
+    {# IF DATE OF BIRTH: #}
+    {% set answerTypeInformation = 'People will only be able to enter a date that is in the past.' %}
   {% else %}
-    {% set inputType = 'No' %}
+    {# IF NOT DATE OF BIRTH: #}
+    {% set answerTypeInformation = 'People will only be able to enter a real date.' %}
   {% endif %}
 {% elif pageData['type'] === 'select' %}
-  {% set answerType = 'Selection from a list' %}
-{% elif pageData['type'] === 'number' %}
-{% elif pageData['type'] === 'text' %}
-  {% set inputTypeTitle = data.textLengthInputTypeTitle %}
-  {% if pageData['input'] === 'single-line-input' %}
-    {% set inputType = 'A single line of text' %}
+  {% if pageData['listSettings'] and ('oneOption' in pageData['listSettings']) %}
+    {# IF RADIOS #}
+    {% set answerTypeInformation = 'People will only be able to select one option.' %}
   {% else %}
-    {% set inputType = 'More than a single line of text' %}
+    {# IF CHECKBOXES #}
+    {% set answerTypeInformation = 'People will need to select at least one option.' %}
+  {% endif %}
+{% elif pageData['type'] === 'number' %}
+  {% set answerTypeInformation = 'People will only be able to enter whole or decimal numbers.' %}
+{% elif pageData['type'] === 'text' %}
+  {% if pageData['input'] === 'single-line-input' %}
+    {# IF ‘SINGLE LINE’ SELECTED: #}
+    {% set answerTypeInformation = 'People will be able to enter up to 499 characters.' %}
+  {% else %}
+    {# IF ‘MULTIPLE LINES’ SELECTED: #}
+    {% set answerTypeInformation = 'People will be able to enter up to 4999 characters.' %}
   {% endif %}
 {% endif %}
 
@@ -74,15 +90,12 @@
     <h1 class="govuk-heading-l">{{pageTitle}}</h1>
 
     <p class="govuk-body">
-      This is how your question will look.
+      The preview below shows how this question will look.
     </p>
 
+    {% if answerTypeInformation %}
     <p class="govuk-body">
-      Answer type: {{ answerType }}
-    </p>
-    {% if inputType %}
-    <p class="govuk-body">
-      Settings: {{ inputType }}
+      {{ answerTypeInformation }}
     </p>
     {% endif %}
 

--- a/app/views/form-designer/pages/preview-question.html
+++ b/app/views/form-designer/pages/preview-question.html
@@ -38,7 +38,7 @@
 {% elif pageData['type'] === 'date' %}
   {% if pageData['input'] === 'yes' %}
     {# IF DATE OF BIRTH: #}
-    {% set answerTypeInformation = 'People will only be able to enter a date that is in the past.' %}
+    {% set answerTypeInformation = 'People will only be able to enter a date that’s in the past.' %}
   {% else %}
     {# IF NOT DATE OF BIRTH: #}
     {% set answerTypeInformation = 'People will only be able to enter a real date.' %}

--- a/app/views/form-designer/pages/preview.html
+++ b/app/views/form-designer/pages/preview.html
@@ -367,8 +367,7 @@
         #}
 
       {# RADIOS #}
-      {% if (pageData['type'] === 'select' and pageData['listSettings'].includes('oneOption')) 
-        or(pageData['type'] === 'yesorno') %}
+      {% if (pageData['type'] === 'select' and pageData['listSettings'] and pageData['listSettings'].includes('oneOption')) or (pageData['type'] === 'yesorno') %}
 
         {% if pageData['type'] === 'yesorno' %}
           {% set itemsArray = ['Yes', 'No'] %}
@@ -416,7 +415,7 @@
         {% endif %}
 
         {# CHECKBOXES #}
-        {% if pageData['type'] == 'select' and not pageData['listSettings'].includes('oneOption') %}
+        {% if pageData['type'] == 'select' and not pageData['listSettings'] %}
 
           {% set itemsArray = pageData['item-list'] %}
 
@@ -442,7 +441,7 @@
                     </label>
                   </div>
                   {% endfor %}
-                  {% if pageData['listSettings'].includes('noneOption') %}
+                  {% if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') %}
                   <div class="govuk-checkboxes__divider">or</div>
                   <div class="govuk-checkboxes__item">
                     <input class="govuk-checkboxes__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="checkbox" value="none" data-behaviour="exclusive">


### PR DESCRIPTION
## What 

Added new content for in journey preview screen, depending on answer type chosen by the form creator. 
Trello card: [Prototype: Add specific content for previewing a question for each different answer and input type](https://trello.com/c/D7PIFDZa/1345-prototype-add-specific-content-for-previewing-a-question-for-each-different-answer-and-input-type)

Added new hint text for “Make this question” optional
Trello card: [Prototype: Add optional setting hint text](https://trello.com/c/97pTrzpl/1344-prototype-add-optional-setting-hint-text)

Fixed some issues with the preview pages not loading for checkboxes. 

## How to check

1. check content to make sure it matches the [agreed content (google doc)](https://docs.google.com/document/d/1QlzCLyoBq0UGqbekcsfnRZEAcZtmlEOUqBN_kYPltHc/edit)
2. check that the content matches the correct answer type