### PR TITLE
2024 02 01 payment link testing screens

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -288,3 +288,8 @@ Summary card
 .app-summary-card .govuk-summary-list__row:last-child,.app-summary-card .govuk-summary-list__row:last-child>* {
   border-bottom: 0
 }
+
+// Payment Link confirmation panel
+.app-panel-blue {
+  background-color: #1d70b8;
+}

--- a/app/views/form-designer/pages/_routes.js
+++ b/app/views/form-designer/pages/_routes.js
@@ -83,8 +83,6 @@ router.post('/form-designer/pages/:pageId(\\d+)/edit-answer-type', function (req
       text: 'Select the type of answer you need',
       href: "#type"
     }
-  } else {
-    pageData['type'] = type
   }
 
   // Convert the errors into a list, so we can use it in the template
@@ -109,6 +107,8 @@ router.post('/form-designer/pages/:pageId(\\d+)/edit-answer-type', function (req
       req.session.data.pages.push({
         'pageIndex': nextPageId
       })
+    } else {
+      pageData['type'] = type
     }
     if (type === 'personName') {
       // person's name route

--- a/app/views/form-designer/pages/confirmation/view.html
+++ b/app/views/form-designer/pages/confirmation/view.html
@@ -12,17 +12,19 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">{{ data['confirmationTitle'] }}</h1>
-    </div>
+    {% set panelHTML %}
+      {{ data['confirmationTitle'] }}
+    {% endset %}
+    
+    {{ govukPanel({
+      titleHtml: panelHTML
+    }) }}
 
-
+    {% if data['confirmationNext'] %}
       <h2 class="govuk-heading-m">What happens next</h2>
-
-      {% if data['confirmationNext'] %}
       <div class="app-prose-scope">
       {% markdown %}
-        {{ data['confirmationNext'] }}
+        {{ data['confirmationNext'] | striptags(true) | escape | nl2br }}
       {% endmarkdown %}
       </div>
     {% endif %}

--- a/app/views/form-designer/pages/edit-answer-type.html
+++ b/app/views/form-designer/pages/edit-answer-type.html
@@ -6,12 +6,6 @@
   {{ "Error: " if containsErrors }}{{ pageTitle }} - GOV.UK Forms
 {% endblock %}
 
-{% set pageNumberTemp %}
-  {% for ref in data.referer.split('/') %}
-    {% if loop.index == loop.length - 1 %}{{ref}}{% endif %}
-  {% endfor %}
-{% endset %}
-
 {% block beforeContent %}
   {# Back links are handled in routes.js #}
   <a class="govuk-back-link" href="{{ previousPageLink }}" target="_parent">

--- a/app/views/form-designer/pages/preview.html
+++ b/app/views/form-designer/pages/preview.html
@@ -50,6 +50,12 @@
         isPageHeading: true if pageData['additional-guidance'] != 'Yes'
       }%}
 
+      {% set legend = {
+        text: pageTitle,
+        classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+        isPageHeading: true if pageData['additional-guidance'] != 'Yes'
+      }%}
+
       {# Full name in a single field #}
       {% if pageData['type'] === 'personName' %}
         {% if (pageData['input'] === 'multi-field') or (pageData['input'] === 'multi-field-plus') %}
@@ -333,7 +339,7 @@
           id: pageId,
           namePrefix: pageId,
           fieldset: {
-            legend: label
+            legend: legend
           },
           hint: {text: pageData['hint-text']},
           items: [
@@ -367,7 +373,7 @@
         #}
 
       {# RADIOS #}
-      {% if (pageData['type'] === 'select' and pageData['listSettings'] and pageData['listSettings'].includes('oneOption')) or (pageData['type'] === 'yesorno') %}
+      {% if pageData['type'] === 'select' %} 
 
         {% if pageData['type'] === 'yesorno' %}
           {% set itemsArray = ['Yes', 'No'] %}
@@ -375,47 +381,47 @@
           {% set itemsArray = pageData['item-list'] %}
         {% endif %}
 
+        {% if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') %}
+
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
 
             {% if not pageData['intro-text'] %}
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                <h1 class="govuk-fieldset__heading">
-                  {{ pageTitle }}
-                  <span class="govuk-visually-hidden">preview</span>
-                </h1>
-              </legend>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h1 class="govuk-fieldset__heading">
+                {{ pageTitle }}<span class="govuk-visually-hidden"> preview</span>
+              </h1>
+            </legend>
             {% endif %}
-
             <div id="question-{{pageId}}-hint" class="govuk-hint">
               {{ pageData['hint-text']}}
             </div>
             <div class="govuk-radios" data-module="govuk-radios">
               {% for itemRaw in itemsArray %}
-                {% set item = itemRaw | trim %}
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}">
-                  <label class="govuk-label govuk-radios__label" for="{{ pageId }}-{{ item }}">
-                    {{ item }}
-                  </label>
-                </div>
-              {% endfor %}
-              {% if pageData['listSettings'].includes('noneOption')%}
-                <div class="govuk-radios__divider">or</div>
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="radio" value="none" data-behaviour="exclusive">
-                  <label class="govuk-label govuk-radios__label" for="question-{{pageId}}-none">
-                    None of the above
-                  </label>
-                </div>
-                {%endif%}
+              {% set item = itemRaw | trim %}
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}">
+                <label class="govuk-label govuk-radios__label" for="{{ pageId }}-{{ item }}">
+                  {{ item }}
+                </label>
               </div>
-            </fieldset>
-          </div>
+              {% endfor %}
+              {% if pageData['listSettings'].includes('noneOption') %}
+              <div class="govuk-radios__divider">or</div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="radio" value="none" data-behaviour="exclusive">
+                <label class="govuk-label govuk-radios__label" for="question-{{pageId}}-none">
+                  None of the above
+                </label>
+              </div>
+              {%endif%}
+            </div>
+          </fieldset>
+        </div>
         {% endif %}
 
         {# CHECKBOXES #}
-        {% if pageData['type'] == 'select' and not pageData['listSettings'] %}
+        {% if not pageData['listSettings'] or (pageData['listSettings'] and not pageData['listSettings'].includes('oneOption')) %}
 
           {% set itemsArray = pageData['item-list'] %}
 
@@ -423,9 +429,9 @@
             <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
 
               {% if not pageData['intro-text'] %}
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                  <h1 class="govuk-fieldset__heading">{{ pageTitle }}</h1>
-                </legend>
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">{{ pageTitle }}</h1>
+              </legend>
               {% endif %}
 
               <div id="question-{{pageId}}-hint" class="govuk-hint">
@@ -433,41 +439,42 @@
               </div>
               <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                 {% if pageData['item-list'] %}
-                  {% for item in itemsArray %}
-                  <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
-                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
-                      {{ item }}
-                    </label>
-                  </div>
-                  {% endfor %}
-                  {% if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') %}
-                  <div class="govuk-checkboxes__divider">or</div>
-                  <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="checkbox" value="none" data-behaviour="exclusive">
-                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-none">
-                      None of the above
-                    </label>
-                  </div>
-                  {% endif %}
+                {% for item in itemsArray %}
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
+                  <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
+                    {{ item }}
+                  </label>
+                </div>
+                {% endfor %}
+                {% if pageData['listSettings'] and pageData['listSettings'].includes('noneOption') %}
+                <div class="govuk-checkboxes__divider">or</div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="checkbox" value="none" data-behaviour="exclusive">
+                  <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-none">
+                    None of the above
+                  </label>
+                </div>
+                {% endif %}
                 {% else %}
-                  <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
-                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
-                      <i>Blank</i>
-                    </label>
-                  </div>
-                  <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
-                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
-                      <i>Blank</i>
-                    </label>
-                  </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                    <i>Blank</i>
+                  </label>
+                </div>
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}">
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                    <i>Blank</i>
+                  </label>
+                </div>
                 {% endif %}
               </div>
             </fieldset>
           </div>
         {% endif %}
+      {% endif %}
 
         {# NUMBER #}
         {% if pageData['type'] == 'number' %}

--- a/app/views/form-designer/partials/status-draft-form.html
+++ b/app/views/form-designer/partials/status-draft-form.html
@@ -143,6 +143,40 @@
     ]
 }) }}
 
+{# SET STATUS OF PAYMENT LINK #}
+{% if data.paymentLink %}
+    {% set paymentLinkStatusText = 'Completed' %}
+{% else %}
+    {% set paymentLinkStatusTag = 'govuk-task-list__status--cannot-start-yet' %}
+    {% set paymentLinkStatusText = 'Optional' %}
+{% endif%}
+{% set htmlPaymentLink %}
+    {% if data.paymentLink %}
+        <strong class="govuk-tag {{ paymentLinkStatusTag }}">
+            {{ paymentLinkStatusText }}
+        </strong>
+    {% else %}
+        {{ paymentLinkStatusText }}
+    {% endif %}
+{% endset %}
+
+<h3 class="govuk-heading-s">Optional tasks</h3>
+{{ govukTaskList({
+    idPrefix: "payment-link",
+    items: [
+        {
+            title: {
+                text: "Add a link to a payment page on GOV.UK Pay"
+            },
+            href: "payment/add-payment-link",
+            status: {
+                html: htmlPaymentLink,
+                classes: paymentLinkStatusTag if not data.paymentLink
+            }
+        }
+    ]
+}) }}
+
 
 {# SET STATUS OF SUBMISSION EMAIL #}
 {# Show a different link and status based on email and confirmation code presence #}
@@ -229,7 +263,8 @@
             } if confirmationCodeStatusHint and confirmationCodeStatusHint != '',
             href: "completed-forms-email/enter-email-confirmation-code" if data.formsEmail and not data.confirmationCode,
             status: {
-                html: htmlSubmissionConfirmation
+                html: htmlSubmissionConfirmation,
+                classes: confirmationCodeStatusTag if (data.formsEmail and data.confirmationCode) or (not (data.formsEmail))
             }
         }
     ]
@@ -337,7 +372,8 @@
             } if sections < 6,
             href: "make-your-form-live" if sections >= 6,
             status: {
-                html: htmlFormVersion
+                html: htmlFormVersion,
+                classes: formVersionStatusTag if (data.status == 'Live') or (sections < 6)
             }
         }
     ]

--- a/app/views/form-designer/partials/status-draft-form.html
+++ b/app/views/form-designer/partials/status-draft-form.html
@@ -150,15 +150,6 @@
     {% set paymentLinkStatusTag = 'govuk-task-list__status--cannot-start-yet' %}
     {% set paymentLinkStatusText = 'Optional' %}
 {% endif%}
-{% set htmlPaymentLink %}
-    {% if data.paymentLink %}
-        <strong class="govuk-tag {{ paymentLinkStatusTag }}">
-            {{ paymentLinkStatusText }}
-        </strong>
-    {% else %}
-        {{ paymentLinkStatusText }}
-    {% endif %}
-{% endset %}
 
 <h3 class="govuk-heading-s">Optional tasks</h3>
 {{ govukTaskList({
@@ -170,7 +161,7 @@
             },
             href: "payment/add-payment-link",
             status: {
-                html: htmlPaymentLink,
+                text: paymentLinkStatusText,
                 classes: paymentLinkStatusTag if not data.paymentLink
             }
         }

--- a/app/views/form-designer/payment/add-payment-link.html
+++ b/app/views/form-designer/payment/add-payment-link.html
@@ -85,6 +85,8 @@
 
         {% endif %}
 
+        <input type="hidden" id="tempPaymentLink" name="tempPaymentLink" value="{{ data.paymentLink }}" />
+
         {{ govukInput({
           label: {
             text: "Enter the URL of your GOV.UK Pay payment link ",

--- a/app/views/form-designer/payment/add-payment-link.html
+++ b/app/views/form-designer/payment/add-payment-link.html
@@ -1,0 +1,140 @@
+{% extends "layout-govuk-forms.html" %}
+
+{% set pageTitle = 'Add a link to a payment page on GOV.UK Pay' %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }}{{ pageTitle }}: {{ data.formTitle or '[formTitle]' }} - GOV.UK Forms
+{% endblock %}
+
+{% block beforeContent %}
+  <a class="govuk-back-link" href="../your-form" target="_parent">
+    Back to create a form
+  </a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+
+        {% if containsErrors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+        {% endif %}
+
+        <span class="govuk-caption-l">{{ data.formTitle or '[formTitle]' }}</span>
+        <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+        <p class="govuk-body">
+          You can set up a payment page (called a ‘payment link’) on GOV.UK Pay - this lets someone make a payment after submitting their form.
+        </p>
+        <p class="govuk-body{% if data['payment-link-content'] === 'long-content' %} govuk-!-margin-bottom-7{% endif %}">
+          You’ll first need to create your payment link using GOV.UK Pay. You can then copy and paste its URL in the box below.
+        </p>
+
+        {% if data['payment-link-content'] !== 'long-content' %}
+        <p class="govuk-body govuk-!-margin-bottom-7">
+          <a class="govuk-link" href="https://www.payments.service.gov.uk/govuk-payment-pages/" target="_blank">
+            Find out how to create a GOV.UK Pay payment link (opens in a new tab)
+          </a>
+        </p>
+        {% endif %}
+
+        {% if (data['payment-link-content'] === 'medium-content') or (data['payment-link-content'] === 'long-content') %}
+          <h2 class="govuk-heading-m">How this will work for people filling in your form</h2>
+
+          <p class="govuk-body">
+            Once someone's submitted their form they'll see a confirmation page showing:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>a blue banner saying “You still need to pay”</li>
+            <li>their GOV.UK Forms reference number</li>
+            <li>a green ‘Continue to pay’ button - this will take them to GOV.UK Pay to make their payment</li>
+          </ul>
+
+          <p class="govuk-body govuk-!-margin-bottom-7">
+            These details will also be included in a confirmation email if someone chooses to receive this.
+          </p>
+
+        {% endif %}
+
+        {% if data['payment-link-content'] === 'long-content' %}
+          <h2 class="govuk-heading-m">
+            Setting up a ‘payment link’ on GOV.UK Pay
+          </h2>
+
+          <p class="govuk-body">
+            Before you can take payments using a payment link you’ll need to:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>set up a <a class="govuk-link" href="https://payments.service.gov.uk/" target="_blank">GOV.UK Pay (opens in a new tab)</a> account if you don't have one</li>
+            <li>talk to your local finance team to set up a payment service provider (PSP)</li>
+          </ul>
+
+          {{ govukInsetText({
+            text: "It may be up to several months before you’re ready to take payments. This depends on the PSP arrangements for your department."
+          }) }}
+
+          <p class="govuk-body govuk-!-margin-bottom-7">
+            <a class="govuk-link" href="https://www.payments.service.gov.uk/govuk-payment-pages/" target="_blank">
+              Find out how to create a GOV.UK Pay payment link (opens in a new tab)
+            </a>
+          </p>
+
+        {% endif %}
+
+        {{ govukInput({
+          label: {
+            text: "Enter the URL of your GOV.UK Pay payment link ",
+            classes: "govuk-label--m"
+          },
+          classes: "govuk-!-width-two-thirds",
+          id: "payment-link",
+          name: "paymentLink",
+          hint: {
+            text: "For example, https://gov.uk/payments/your-payment-link"
+          },
+          value: data['paymentLink'],
+          errorMessage: {
+            text: errors['paymentLink'].text } if errors['paymentLink'].text
+        }) }}
+
+        {{ govukButton({
+          text: "Save and continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {{ govukFooter({
+    meta: {
+      items: [
+        {
+          href: "?payment-link-content=short-content",
+          text: "Short content"
+        },
+        {
+          href: "?payment-link-content=medium-content",
+          text: "Medium content"
+        },
+        {
+          href: "?payment-link-content=long-content",
+          text: "Long content"
+        },
+        {
+          href: "/prototype-admin/show-data",
+          text: "Show data"
+        },
+        {
+          href: "/manage-prototype/clear-data",
+          text: "Clear data"
+        }
+      ]
+    }
+  }) }}
+{% endblock %}

--- a/app/views/form-designer/payment/payment-link-example.html
+++ b/app/views/form-designer/payment/payment-link-example.html
@@ -1,0 +1,65 @@
+{% extends "layout-govuk-form-preview.html" %}
+{% set mainClasses = "main--draft govuk-main-wrapper--auto-spacing" %}
+
+{% set pageTitle = 'Pay for ' + (data.formTitle|lower or '[paymentLinkTitle]') %}
+{% set serviceName = pageTitle %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    serviceName: pageTitle,
+    serviceUrl: "../your-questions"
+  }) }}
+{% endblock %}
+
+{% block pageTitle %}
+  {{ "Error: " if containsErrors }}{{ pageTitle }} - Example preview - GOV.UK Forms
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post" novalidate>
+
+        {% if containsErrors %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorList
+        }) }}
+        {% endif %}
+
+        <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+        <h2 class="govuk-heading-m">
+          Check your details
+        </h2>
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Reference number"
+              },
+              value: {
+                text: reference
+              }
+            },
+            {
+              key: {
+                text: "Total to pay"
+              },
+              value: {
+                text: "£40.00"
+              }
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue to payment"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/form-designer/preview/confirmation.html
+++ b/app/views/form-designer/preview/confirmation.html
@@ -9,12 +9,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    {% set panelHTML %}
-      {{ data['confirmationTitle'] }} <span class="govuk-visually-hidden">preview</span>
+    {% set titleHTML %}
+      {% if data.paymentLink %}
+      You still need to pay
+      {% else %}
+      {{ data['confirmationTitle'] }}
+      {% endif %}
+      <span class="govuk-visually-hidden"> preview</span>
+    {% endset %}
+
+    {% set referenceNumber = 'HDJ2123F' %}
+
+    {% set referenceHTML %}
+      Your reference number is<br>
+      <strong>{{ referenceNumber }}</strong>
     {% endset %}
 
     {{ govukPanel({
-      titleHtml: panelHTML
+      titleHtml: titleHTML,
+      html: referenceHTML,
+      classes: 'app-panel-blue' if data.paymentLink
     }) }}
 
     {% if data['confirmationNext'] %}
@@ -24,6 +38,16 @@
         {{ data['confirmationNext'] | striptags(true) | escape | nl2br }}
       {% endmarkdown %}
       </div>
+    {% endif %}
+
+    {% if data.paymentLink %}
+      {{ govukButton({
+        text: "Continue to pay",
+        href: '../payment/payment-link-example?reference=' + referenceNumber,
+        attributes: {
+          target: "_parent"
+        }
+      }) }}
     {% endif %}
 
   </div>

--- a/app/views/form-designer/preview/page.html
+++ b/app/views/form-designer/preview/page.html
@@ -53,6 +53,12 @@
           isPageHeading: true if pageData['additional-guidance'] != 'Yes'
         }%}
 
+        {% set legend = {
+          text: pageTitle,
+          classes: "govuk-fieldset__legend--l" if pageData['additional-guidance'] != 'Yes' else "govuk-fieldset__legend--m",
+          isPageHeading: true if pageData['additional-guidance'] != 'Yes'
+        }%}
+
         {# Full name in a single field #}
         {% if pageData['type'] === 'personName' %}
           {% if (pageData['input'] === 'multi-field') or (pageData['input'] === 'multi-field-plus') %}
@@ -333,9 +339,11 @@
           id: pageId,
           namePrefix: pageId,
           fieldset: {
-            legend: label
+            legend: legend
           },
-          hint: {text: pageData['hint-text']},
+          hint: {
+            text: pageData['hint-text']
+          },
           items: [
             {
               name: "day",
@@ -367,7 +375,7 @@
         #}
 
         {# Radios #}
-        {% if (pageData['type'] === 'select' and pageData['listSettings'].includes('oneOption')) or (pageData['type'] === 'yesorno') %}
+        {% if pageData['type'] === 'select' %}
 
           {% if pageData['type'] === 'yesorno' %}
             {% set itemsArray = ['Yes', 'No'] %}
@@ -375,97 +383,99 @@
             {% set itemsArray = pageData['item-list'] %}
           {% endif %}
 
-          <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
+          {% if pageData['listSettings'] and pageData['listSettings'].includes('oneOption') %}
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
 
-              {% if not pageData['intro-text'] %}
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                  <h1 class="govuk-fieldset__heading">
-                    {{ pageTitle }} <span class="govuk-visually-hidden">preview</span>
-                  </h1>
-                </legend>
-              {% endif %}
+                {% if not pageData['intro-text'] %}
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <h1 class="govuk-fieldset__heading">
+                      {{ pageTitle }} <span class="govuk-visually-hidden">preview</span>
+                    </h1>
+                  </legend>
+                {% endif %}
 
-              <div id="question-{{pageId}}-hint" class="govuk-hint">
-                {{ pageData['hint-text']}}
-              </div>
-              <div class="govuk-radios" data-module="govuk-radios">
-                {% for itemRaw in itemsArray %}
-                {% set item = itemRaw | trim %}
-                  <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}" {{ checked(pageId, item) }}>
-                    <label class="govuk-label govuk-radios__label" for="{{ pageId }}-{{ item }}">
-                      {{ item }}
-                    </label>
-                  </div>
-                {% endfor %}
-                {% if pageData['listSettings'].includes('noneOption')%}
-                <div class="govuk-radios__divider">or</div>
-                  <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="radio" value="none" data-behaviour="exclusive">
-                    <label class="govuk-label govuk-radios__label" for="question-{{pageId}}-none">
-                      None of the above
-                    </label>
-                  </div>
-                {%endif%}
-              </div>
-            </fieldset>
-          </div>
-        {% endif %}
-
-        {# Checkboxes #}
-        {% if pageData['type'] == 'select' and not pageData['listSettings'].includes('oneOption') %}
-
-          {% set itemsArray = pageData['item-list'] %}
-
-          <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
-
-              {% if not pageData['intro-text'] %}
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                  <h1 class="govuk-fieldset__heading">{{ pageTitle }}</h1>
-                </legend>
-              {% endif %}
-
-              <div id="question-{{pageId}}-hint" class="govuk-hint">
-                {{ pageData['hint-text']}}
-              </div>
-              <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                {% if pageData['item-list'] %}
-                  {% for item in itemsArray %}
-                  <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
-                      {{ item }}
-                    </label>
-                  </div>
+                <div id="question-{{pageId}}-hint" class="govuk-hint">
+                  {{ pageData['hint-text']}}
+                </div>
+                <div class="govuk-radios" data-module="govuk-radios">
+                  {% for itemRaw in itemsArray %}
+                  {% set item = itemRaw | trim %}
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="radio" value="{{ item }}" {{ checked(pageId, item) }}>
+                      <label class="govuk-label govuk-radios__label" for="{{ pageId }}-{{ item }}">
+                        {{ item }}
+                      </label>
+                    </div>
                   {% endfor %}
                   {% if pageData['listSettings'].includes('noneOption')%}
-                  <div class="govuk-checkboxes__divider">or</div>
+                  <div class="govuk-radios__divider">or</div>
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="radio" value="none" data-behaviour="exclusive">
+                      <label class="govuk-label govuk-radios__label" for="question-{{pageId}}-none">
+                        None of the above
+                      </label>
+                    </div>
+                  {%endif%}
+                </div>
+              </fieldset>
+            </div>
+          {% endif %}
+
+          {# Checkboxes #}
+          {% if not pageData['listSettings'] or (pageData['listSettings'] and not pageData['listSettings'].includes('oneOption')) %}
+
+            {% set itemsArray = pageData['item-list'] %}
+
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset" aria-describedby="question-{{pageId}}-hint">
+
+                {% if not pageData['intro-text'] %}
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                    <h1 class="govuk-fieldset__heading">{{ pageTitle }}</h1>
+                  </legend>
+                {% endif %}
+
+                <div id="question-{{pageId}}-hint" class="govuk-hint">
+                  {{ pageData['hint-text']}}
+                </div>
+                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                  {% if pageData['item-list'] %}
+                    {% for item in itemsArray %}
+                    <div class="govuk-checkboxes__item">
+                      <input class="govuk-checkboxes__input" id="question-{{pageId}}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                      <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-{{ item }}">
+                        {{ item }}
+                      </label>
+                    </div>
+                    {% endfor %}
+                    {% if pageData['listSettings'].includes('noneOption')%}
+                    <div class="govuk-checkboxes__divider">or</div>
+                    <div class="govuk-checkboxes__item">
+                      <input class="govuk-checkboxes__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="checkbox" value="none" data-behaviour="exclusive">
+                      <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-none">
+                        None of the above
+                      </label>
+                    </div>
+                    {%endif%}
+                  {% else %}
                   <div class="govuk-checkboxes__item">
-                    <input class="govuk-checkboxes__input" id="question-{{pageId}}-none" name="{{ pageId }}" type="checkbox" value="none" data-behaviour="exclusive">
-                    <label class="govuk-label govuk-checkboxes__label" for="question-{{pageId}}-none">
-                      None of the above
+                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                      <i>Blank</i>
                     </label>
                   </div>
-                  {%endif%}
-                {% else %}
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
-                    <i>Blank</i>
-                  </label>
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
+                    <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
+                      <i>Blank</i>
+                    </label>
+                  </div>
+                  {% endif %}
                 </div>
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="{{ pageId }}-{{ item }}" name="{{ pageId }}" type="checkbox" value="{{ item }}" {{ checked(pageId, item) }}>
-                  <label class="govuk-label govuk-checkboxes__label" for="{{ pageId }}-{{ item }}">
-                    <i>Blank</i>
-                  </label>
-                </div>
-                {% endif %}
-              </div>
-            </fieldset>
-          </div>
+              </fieldset>
+            </div>
+          {% endif %}
         {% endif %}
 
         {# Number fields #}


### PR DESCRIPTION
## What

- New add payment link task to task list
- New payment page with 3 version of content length, short, medium and long (linked in the footer)
- Simple validation on URL input, with success messaging
    - no content work has been done on these yet
- Updated confirmation screen of the preview your form journey to include blue banner, content and payment CTA
- Added an example mockup of what the GOV.UK Pay payment page would look like for form fillers

### Bug fixes
- There was an error with adding answer types, but not sure what happened - all working again now
- Issue with fieldset legends not displaying correctly - this has been fixed

## How to check

[PR Heroku app link](https://forms-prototypes-pr-216.herokuapp.com/)

1. check the content matches agreed content on testing area of [mural board](https://app.mural.co/t/gaap0347/m/gaap0347/1697117881057/d45c5ac653b9730a76915e77f257bacdcbb40047?wid=0-1706025455465)
2. double check the journey work as expected