### PR TITLE
Update govuk-frontend to 5.2.0

### DIFF
--- a/app/views/example-1/check-your-answers.html
+++ b/app/views/example-1/check-your-answers.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/confirmation.html
+++ b/app/views/example-1/confirmation.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/example-1/question-1.html
+++ b/app/views/example-1/question-1.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-2.html
+++ b/app/views/example-1/question-2.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-3.html
+++ b/app/views/example-1/question-3.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-4.html
+++ b/app/views/example-1/question-4.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-5.html
+++ b/app/views/example-1/question-5.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-6.html
+++ b/app/views/example-1/question-6.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-7.html
+++ b/app/views/example-1/question-7.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/question-8.html
+++ b/app/views/example-1/question-8.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-1/start.html
+++ b/app/views/example-1/start.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/check-your-answers.html
+++ b/app/views/example-2/check-your-answers.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/confirmation.html
+++ b/app/views/example-2/confirmation.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/example-2/eligibility-check.html
+++ b/app/views/example-2/eligibility-check.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/ineligible.html
+++ b/app/views/example-2/ineligible.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-1.html
+++ b/app/views/example-2/question-1.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-2.html
+++ b/app/views/example-2/question-2.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-3.html
+++ b/app/views/example-2/question-3.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-4.html
+++ b/app/views/example-2/question-4.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-5.html
+++ b/app/views/example-2/question-5.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-6.html
+++ b/app/views/example-2/question-6.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/question-7.html
+++ b/app/views/example-2/question-7.html
@@ -10,7 +10,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/example-2/question-8.html
+++ b/app/views/example-2/question-8.html
@@ -10,7 +10,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/example-2/return-check.html
+++ b/app/views/example-2/return-check.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/return.html
+++ b/app/views/example-2/return.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/save-progress-check.html
+++ b/app/views/example-2/save-progress-check.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/save-progress-confirm.html
+++ b/app/views/example-2/save-progress-confirm.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/save-progress.html
+++ b/app/views/example-2/save-progress.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/start.html
+++ b/app/views/example-2/start.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/example-2/task-list-v2.html
+++ b/app/views/example-2/task-list-v2.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/example-2/task-list.html
+++ b/app/views/example-2/task-list.html
@@ -6,7 +6,7 @@
 
 {% block header %}
   <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
+  {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/layout-body-only.html
+++ b/app/views/layout-body-only.html
@@ -10,8 +10,7 @@
     serviceName: data['formTitle'],
     containerClasses: "govuk-width-container",
     navigationClasses: "govuk-header__navigation--end govuk-!-display-block",
-    classes: "app-preview-header-container",
-    useTudorCrown: true
+    classes: "app-preview-header-container"
   }) }}
 {% endblock %}
 

--- a/app/views/layout-govuk-form-preview.html
+++ b/app/views/layout-govuk-form-preview.html
@@ -12,8 +12,7 @@
         href: "../your-questions",
         text: "Your questions"
       }
-    ],
-    useTudorCrown: true
+    ]
   }) }}
 {% endblock %}
 

--- a/app/views/layout-govuk-forms.html
+++ b/app/views/layout-govuk-forms.html
@@ -16,8 +16,7 @@
       href: "/form-designer/signon/sign-in",
       text: "Sign out"
     }
-  ],
-  useTudorCrown: true
+  ]
   }) }}
 {% endblock %}
 

--- a/app/views/layout-unbranded-preview.html
+++ b/app/views/layout-unbranded-preview.html
@@ -10,8 +10,7 @@
     serviceName: data['formTitle'],
     containerClasses: "govuk-width-container",
     navigationClasses: "govuk-header__navigation--end govuk-!-display-block",
-    classes: "app-preview-header-container",
-    useTudorCrown: true
+    classes: "app-preview-header-container"
   }) }}
 {% endblock %}
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,10 +1,5 @@
 {% extends "govuk-prototype-kit/layouts/govuk-branded.html" %}
 
-{% block header %}
-  <!-- Blank header with no service name for the start page -->
-  {{ govukHeader({ useTudorCrown: true }) }}
-{% endblock %}
-
 {# Local macros #}
 {% from "./macros/comment.njk" import comment %}
 {% from "./macros/comment.njk" import reply %}

--- a/app/views/publisher/confirm-email.html
+++ b/app/views/publisher/confirm-email.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/declaration.html
+++ b/app/views/publisher/declaration.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/email-confirmed.html
+++ b/app/views/publisher/email-confirmed.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/enter-email.html
+++ b/app/views/publisher/enter-email.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/form-summary.html
+++ b/app/views/publisher/form-summary.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/published.html
+++ b/app/views/publisher/published.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/review-question.html
+++ b/app/views/publisher/review-question.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/review.html
+++ b/app/views/publisher/review.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/reviewers.html
+++ b/app/views/publisher/reviewers.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/start.html
+++ b/app/views/publisher/start.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/publisher/unpublish-confirm.html
+++ b/app/views/publisher/unpublish-confirm.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/app/views/publisher/versions.html
+++ b/app/views/publisher/versions.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block header %}
-    {{ govukHeader({ useTudorCrown: true }) }}
+    {{ govukHeader() }}
     {% include "includes/submenu.html" %}
 {% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@govuk-prototype-kit/common-templates": "1.2.2",
         "@govuk-prototype-kit/step-by-step": "^2.1.0",
         "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
-        "govuk-frontend": "^5.1.0",
+        "govuk-frontend": "^5.2.0",
         "govuk-markdown": "^0.4.0",
         "govuk-prototype-kit": "^13.4.0",
         "jquery": "^3.6.4",
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.1.0.tgz",
-      "integrity": "sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -4913,9 +4913,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.1.0.tgz",
-      "integrity": "sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
+      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw=="
     },
     "govuk-markdown": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@govuk-prototype-kit/common-templates": "1.2.2",
     "@govuk-prototype-kit/step-by-step": "^2.1.0",
     "@lfdebrux/nunjucks-markdown": "github:lfdebrux/govuk-prototype-kit-nunjucks-markdown-plugin#v0.0.3",
-    "govuk-frontend": "^5.1.0",
+    "govuk-frontend": "^5.2.0",
     "govuk-markdown": "^0.4.0",
     "govuk-prototype-kit": "^13.4.0",
     "jquery": "^3.6.4",


### PR DESCRIPTION
### Update the govuk-frontend version to 5.2.0

This comes quickly after the previous PR to explicitly use the new tudor crown by setting the `useTudorCrown` parameter.

5.2.0 shows the Tudor crown by default so the parameter can be removed.

It makes sense to revert the previous commit while nothing has changed and update the library.
