### PR TITLE
Small change on change the name of the group link

### DIFF
--- a/app/views/product-pages/group-admin/grouplanding2.html
+++ b/app/views/product-pages/group-admin/grouplanding2.html
@@ -23,7 +23,7 @@
     <h1 class="govuk-heading-l">{{ data['groupName'] or 'Your test forms' }}</h1>
 
     <p class="govuk-body">
-      <a href="grouplanding" class="govuk-link">Change the name of this group</a>
+      <a href="grouplanding2" class="govuk-link">Change the name of this group</a>
     </p>
     <p class="govuk-body">
       <a href="editmembers" class="govuk-link">Edit members of this group</a>


### PR DESCRIPTION
The link to 'change your name group' leads to a different group landing page, changing that so that the link is inactive and user remains on that same page