### PR TITLE
2024 05 21 performance dashboard

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -1,2 +1,33 @@
 const govukPrototypeKit = require('govuk-prototype-kit')
 const addFilter = govukPrototypeKit.views.addFilter
+
+addFilter('commaFormat', function (inputString) {
+    inputString = inputString.toString();
+    var decimalPart = "";
+    if (inputString.indexOf('.') != -1) {
+        //alert("decimal number");
+        inputString = inputString.split(".");
+        decimalPart = "." + inputString[1];
+        inputString = inputString[0];
+        //alert(inputString);
+        //alert(decimalPart);
+
+    }
+    var outputString = "";
+    var count = 0;
+    for (var i = inputString.length - 1; i >= 0 && inputString.charAt(i) != '-'; i--) {
+        //alert("inside for" + inputString.charAt(i) + "and count=" + count + " and outputString=" + outputString);
+        if (count == 3) {
+            outputString += ",";
+            count = 0;
+        }
+        outputString += inputString.charAt(i);
+        count++;
+    }
+    if (inputString.charAt(0) == '-') {
+        outputString += "-";
+    }
+    //alert(outputString);
+    //alert(outputString.split("").reverse().join(""));
+    return outputString.split("").reverse().join("") + decimalPart;
+})

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -38,6 +38,9 @@
       ## [Figma prototypes](https://www.figma.com/files/project/34163725/GOV.UK-Forms?fuid=822552076153840665)
       Sketches, prototypes and other design assets - you'll need access to the GDS Figma account to view these.
 
+      ## [Performance data page](product-pages/performance)
+      Mockup of performance data page to be added to the product site.
+
       ---
 
       [Source code available on GitHub](https://github.com/alphagov/forms-prototypes)

--- a/app/views/product-pages/performance.html
+++ b/app/views/product-pages/performance.html
@@ -1,0 +1,327 @@
+{% extends "layout.html" %} 
+
+{% set pageTitle = 'Performance data' %} 
+
+{% block pageTitle %}
+{{ pageTitle }} - GOV.UK Forms
+{% endblock %}
+
+{% set orgs = [
+  {
+    Organisation: "Government Digital Service",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Ofqual",
+    LiveForms: 1
+  },
+  {
+    Organisation: "UK Space Agency",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Driver and Vehicle Standards Agency",
+    LiveForms: 5
+  },
+  {
+    Organisation: "Department for Environment, Food & Rural Affairs",
+    LiveForms: 3
+  },
+  {
+    Organisation: "Department for Transport",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Government Commercial Function",
+    LiveForms: 4
+  },
+  {
+    Organisation: "Valuation Office Agency",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Attorney General's Office",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Defence Science and Technology Laboratory",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Home Office",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Ministry of Defence",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Companies House",
+    LiveForms: 2
+  },
+  {
+    Organisation: "Environment Agency",
+    LiveForms: 0
+  },
+  {
+    Organisation: "HM Land Registry",
+    LiveForms: 9
+  },
+  {
+    Organisation: "Defence Safety Authority",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Defence Business Services",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Marine Management Organisation",
+    LiveForms: 2
+  },
+  {
+    Organisation: "Medicines and Healthcare products Regulatory Agency",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Maritime and Coastguard Agency",
+    LiveForms: 1
+  },
+  {
+    Organisation: "The Scottish Government",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Department for Business and Trade",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Food Standards Agency",
+    LiveForms: 2
+  },
+  {
+    Organisation: "Department for Science, Innovation and Technology",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Foreign, Commonwealth & Development Office",
+    LiveForms: 2
+  },
+  {
+    Organisation: "The Insolvency Service",
+    LiveForms: 4
+  },
+  {
+    Organisation: "Central Digital and Data Office",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Department for Education",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Competition and Markets Authority",
+    LiveForms: 0
+  },
+  {
+    Organisation: "Cabinet Office",
+    LiveForms: 2
+  },
+  {
+    Organisation: "Department of Health and Social Care",
+    LiveForms: 2
+  },
+  {
+    Organisation: "Office for Health Improvement and Disparities",
+    LiveForms: 1
+  },
+  {
+    Organisation: "Commission for Countering Extremism",
+    LiveForms: 1
+  }
+] %}
+{% set submissions = 101993 %}
+
+
+{% block stylesheets %}
+{% include "govuk-prototype-kit/includes/stylesheets.html" %}
+<link
+  href="/public/stylesheets/product-page.css"
+  rel="stylesheet"
+  type="text/css"
+/>
+{% endblock %}
+
+{% block header %}
+<header class="govuk-header" role="banner" data-module="govuk-header" id="top">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <a
+        href="/product-pages/signup/"
+        class="govuk-header__link govuk-header__link--homepage"
+      >
+        <span class="govuk-header__logotype">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 132 97"
+            height="30"
+            width="36"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+          </svg>
+          <span class="govuk-header__logotype-text"> GOV.UK </span>
+        </span>
+        <span class="govuk-header__product-name">
+          Forms
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            beta
+          </strong>
+        </span>
+      </a>
+    </div>
+    <div class="govuk-header__content">
+      <nav aria-label="Menu" class="govuk-header__navigation">
+        <button
+          type="button"
+          class="govuk-header__menu-button govuk-js-header-toggle"
+          aria-controls="navigation"
+          aria-label="Show or hide menu"
+          hidden=""
+        >
+          Menu
+        </button>
+
+        <ul id="navigation" class="govuk-header__navigation-list" hidden="">
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="get-started"> Get started </a>
+          </li>
+          <li
+            class="govuk-header__navigation-item govuk-header__navigation-item--active"
+          >
+            <a class="govuk-header__link" href="features"> Features </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="support"> Support </a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a
+              class="govuk-header__link"
+              href="https://admin.research.forms.service.gov.uk/"
+            >
+              Sign in
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</header>
+{% endblock header %}
+
+{% block beforeContent %}
+{{ govukBreadcrumbs({
+  items: [
+    {
+      text: "GOV.UK services",
+      href: "https://www.gov.uk/service-toolkit#gov-uk-services"
+    },
+    {
+      text: "GOV.UK Forms",
+      href: "signup"
+    },
+    {
+      text: "Performance data",
+      href: "#"
+    }
+  ]
+}) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+
+    <h2 class="govuk-heading-m">Since April 2024</h2>
+
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <div class="govuk-heading-l govuk-!-margin-bottom-0">{{ submissions|int }}</div>
+        <div class="govuk-body">submissions</div>
+      </div>
+
+      <div class="govuk-grid-column-one-half">
+        <div class="govuk-heading-l govuk-!-margin-bottom-0">{{ ((submissions|int * 2) / 1440)|int }}</div>
+        <div class="govuk-body">
+          processing days saved
+          <br><span class="govuk-body-s">based on an average of 2 minutes per form</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-body-s">Last updated: 21 May 2024</div>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0">
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">Organisations using GOV.UK Forms</h2>
+
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
+      <div class="govuk-grid-column-one-half">
+        <div class="govuk-heading-l govuk-!-margin-bottom-0">{{ orgs.length }}</div>
+        <div class="govuk-body">organisations</div>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <div class="govuk-heading-l govuk-!-margin-bottom-0">
+        {% set totalLive = 0 %}
+        {% for org in orgs -%}
+        {% if org.LiveForms %}{% set totalLive = totalLive + org.LiveForms|int %}{% endif %}
+        {%- endfor %}
+        {{ totalLive|int }}
+        </div>
+        <div class="govuk-body">live forms</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table govuk-!-margin-top-4">
+      <caption class="govuk-visually-hidden">
+        Live services per organisation
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Organisations</th>
+          <th scope="col" class="govuk-table__header">Number of live services</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      {% for org in orgs | sort(attribute="Organisation") %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            {{ org.Organisation }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ org.LiveForms }}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+</div>
+{% endblock %}

--- a/app/views/product-pages/performance.html
+++ b/app/views/product-pages/performance.html
@@ -253,7 +253,7 @@
 
     <div class="govuk-grid-row govuk-!-margin-bottom-4">
       <div class="govuk-grid-column-one-half">
-        <div class="govuk-heading-l govuk-!-margin-bottom-0">{{ submissions|int }}</div>
+        <div class="govuk-heading-l govuk-!-margin-bottom-0">{{ submissions|commaFormat }}</div>
         <div class="govuk-body">submissions</div>
       </div>
 

--- a/app/views/product-pages/performance.html
+++ b/app/views/product-pages/performance.html
@@ -305,7 +305,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Organisations</th>
-          <th scope="col" class="govuk-table__header">Number of live services</th>
+          <th scope="col" class="govuk-table__header">Number of live forms</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">


### PR DESCRIPTION
Added design mockup for a performance data page that would appear on the product site. 

This work is covered by [trello card](https://trello.com/c/mnHz11cx/1488-design-spike-publish-data-on-the-performance-of-govuk-forms) and replicates the dashboards offered by other GDS product sites ([Pay](https://payments.service.gov.uk/performance) and [Notify](https://www.notifications.service.gov.uk/features/performance))

It includes the data we can currently get access to only (to be manually updated until we can look at what can be automated). 